### PR TITLE
fix(backend): wire self-hosted MinIO + add missing pymongo dep

### DIFF
--- a/backend/charts/minio/local_omi_minio_values.yaml
+++ b/backend/charts/minio/local_omi_minio_values.yaml
@@ -1,0 +1,28 @@
+# Local (self-hosted) MinIO values for the omi backend.
+# Install as helm release name "omi" so the Service is named "omi-minio",
+# matching S3_ENDPOINT_URL=http://omi-minio:9000 in the backend Deployment.
+
+storage:
+  size: 50Gi
+  # Longhorn = replicated/durable in-cluster storage (survives node reschedule),
+  # unlike microk8s-hostpath which pins data to a single node.
+  storageClassName: longhorn
+
+# Credentials are shared with the backend via the same secret keys, so MinIO's
+# root user == the app's S3_ACCESS_KEY_ID and the buckets are readable by both.
+auth:
+  existingSecret: dev-omi-backend-secrets
+  accessKeyKey: S3_ACCESS_KEY_ID
+  secretKeyKey: S3_SECRET_ACCESS_KEY
+
+# Buckets MUST match the live BUCKET_* values the backend reads from the secret,
+# otherwise uploads fail with NoSuchBucket:
+#   BUCKET_SPEECH_PROFILES -> omi-chakra
+#   BUCKET_POSTPROCESSING  -> omi-chakra-convos
+#   BUCKET_PLUGINS_LOGOS   -> omi-chakra-apps
+# omi-private-cloud-sync is the storage.py default for BUCKET_PRIVATE_CLOUD_SYNC.
+buckets:
+  - omi-chakra
+  - omi-chakra-convos
+  - omi-chakra-apps
+  - omi-private-cloud-sync

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -59,6 +59,7 @@ google-auth-httplib2==0.2.0
 google-cloud-core==2.4.1
 google-cloud-firestore==2.20.0
 google-crc32c==1.5.0
+pymongo==4.8.0  # required by database/mongo_firestore.py (Firestore->Mongo shim)
 google-resumable-media==2.7.1
 googleapis-common-protos==1.63.2
 graphviz==0.20.3

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -36,3 +36,10 @@ deploy:
         setValueTemplates:
           image.repository: "{{.IMAGE_REPO_192_168_1_42_32000_backend_listen}}"
           image.tag: "{{.IMAGE_TAG_192_168_1_42_32000_backend_listen}}"
+      # Self-hosted S3-compatible object storage. Release name "omi" -> Service
+      # "omi-minio", matching S3_ENDPOINT_URL in the backend Deployment.
+      - name: omi
+        chartPath: backend/charts/minio
+        namespace: omi
+        valuesFiles:
+          - backend/charts/minio/local_omi_minio_values.yaml


### PR DESCRIPTION
## Summary

The `omi-backend` pod failed to start in k8s — `CreateContainerConfigError` → `CrashLoopBackOff`. Three layered gaps behind the one symptom:

1. **MinIO was never deployed.** The backend points at `S3_ENDPOINT_URL=http://omi-minio:9000`, but the `backend/charts/minio` chart was never installed, and the secret was missing `S3_ACCESS_KEY_ID`/`S3_SECRET_ACCESS_KEY` (the literal `CreateContainerConfigError`). Wired the minio chart into `skaffold.yaml` as release `omi` with a values override whose bucket names match the **live** `BUCKET_*` config (`omi-chakra`, `omi-chakra-convos`, `omi-chakra-apps`, `omi-private-cloud-sync`) on durable `longhorn` storage.
2. **`pymongo` missing from `requirements.txt`.** `database/mongo_firestore.py` (the Firestore→Mongo shim) imports `pymongo`, but the dep was never added → `ModuleNotFoundError: No module named 'pymongo'`. Added `pymongo==4.8.0`.

This is self-hosted storage: MinIO speaks the S3 API but runs entirely in-cluster (data on the node's longhorn PVC) — no cloud dependency.

## Changes
- `backend/requirements.txt` — add `pymongo==4.8.0`
- `backend/charts/minio/local_omi_minio_values.yaml` (new) — bucket names matching live config + longhorn
- `skaffold.yaml` — add the `omi` MinIO helm release

## Operational note (not in this PR)
The secret `dev-omi-backend-secrets` is **hand-managed in-cluster** (no External Secrets Operator, not in git). It must carry `S3_ACCESS_KEY_ID`/`S3_SECRET_ACCESS_KEY` — these are shared by the MinIO root user **and** the backend's S3 client (the minio chart reads the same secret keys, so they can't drift).

## Verification
- `skaffold run` (skaffold v2.21.0 + helm v4.2.0): build → push → helm deploy, exit 0
- `omi-backend` & `omi-minio` pods `1/1 Running`, clean startup
- Backend's own S3 client lists all 4 buckets; `pymongo 4.8.0` imports in-container

🤖 Generated with [Claude Code](https://claude.com/claude-code)