### PR TITLE
feat(desktop-rust): Phase 2 — serve Firestore from MongoDB via a shim (merge-friendly)

### DIFF
--- a/desktop/Backend-Rust/Cargo.lock
+++ b/desktop/Backend-Rust/Cargo.lock
@@ -26,7 +26,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -41,6 +41,19 @@ dependencies = [
  "ctr",
  "ghash",
  "subtle",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -60,6 +73,12 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arc-swap"
@@ -207,12 +226,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bson"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969a9ba84b0ff843813e7249eed1678d9b6607ce5a3b8f0a47af3fcf7978e6e"
+dependencies = [
+ "ahash",
+ "base64 0.22.1",
+ "bitvec",
+ "chrono",
+ "getrandom 0.2.17",
+ "getrandom 0.3.4",
+ "hex",
+ "indexmap",
+ "js-sys",
+ "once_cell",
+ "rand 0.9.3",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "time",
+ "uuid",
 ]
 
 [[package]]
@@ -242,6 +297,17 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -288,6 +354,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -323,6 +418,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -330,6 +434,12 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-channel"
@@ -341,10 +451,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -385,7 +510,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
@@ -406,6 +531,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,6 +588,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive-syn-parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d65d7ce8132b7c0e54497a4d9a55a1c2a0912a0d786cf894472ba818fba45762"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive-where"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -491,6 +701,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "elliptic-curve"
@@ -583,6 +799,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -605,6 +827,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -739,8 +967,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -750,9 +980,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -816,15 +1062,100 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hickory-net"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "hickory-proto",
+ "idna",
+ "ipnet",
+ "jni",
+ "rand 0.10.1",
+ "thiserror",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-proto"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.1",
+ "ring",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-net",
+ "hickory-proto",
+ "ipconfig",
+ "ipnet",
+ "jni",
+ "moka",
+ "ndk-context",
+ "once_cell",
+ "parking_lot",
+ "rand 0.10.1",
+ "resolv-conf",
+ "smallvec",
+ "system-configuration 0.7.0",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "hkdf"
@@ -1114,6 +1445,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1141,7 +1484,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1154,16 +1499,81 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipconfig"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
+dependencies = [
+ "socket2 0.6.2",
+ "widestring",
+ "windows-registry",
+ "windows-result",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "js-sys"
@@ -1209,6 +1619,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1248,6 +1664,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "macro_magic"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc33f9f0351468d26fbc53d9ce00a096c8522ecb42f19b50f34f2c422f76d21d"
+dependencies = [
+ "macro_magic_core",
+ "macro_magic_macros",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "macro_magic_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1687dc887e42f352865a393acae7cf79d98fab6351cde1f58e9e057da89bf150"
+dependencies = [
+ "const-random",
+ "derive-syn-parse",
+ "macro_magic_core_macros",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "macro_magic_core_macros"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b02abfe41815b5bd98dbd4260173db2c116dda171dc0fe7838cb206333b83308"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "macro_magic_macros"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ea28ee64b88876bf45277ed9a5817c1817df061a74f2b988971a12570e5869"
+dependencies = [
+ "macro_magic_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1261,6 +1725,16 @@ name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
 
 [[package]]
 name = "memchr"
@@ -1296,6 +1770,99 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
+
+[[package]]
+name = "mongocrypt"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da0cd419a51a5fb44819e290fbdb0665a54f21dead8923446a799c7f4d26ad9"
+dependencies = [
+ "bson",
+ "mongocrypt-sys",
+ "once_cell",
+ "serde",
+]
+
+[[package]]
+name = "mongocrypt-sys"
+version = "0.1.5+1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224484c5d09285a7b8cb0a0c117e847ebd14cb6e4470ecf68cdb89c503b0edb9"
+
+[[package]]
+name = "mongodb"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "276ba0cd571553d1f6936c6f180964776ece6ab7507dc8765f8a9c9c49d8cd00"
+dependencies = [
+ "base64 0.22.1",
+ "bitflags 2.11.1",
+ "bson",
+ "derive-where",
+ "derive_more",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "hex",
+ "hickory-net",
+ "hickory-proto",
+ "hickory-resolver",
+ "hmac",
+ "macro_magic",
+ "md-5",
+ "mongocrypt",
+ "mongodb-internal-macros",
+ "pbkdf2",
+ "percent-encoding",
+ "rand 0.9.3",
+ "rustc_version_runtime",
+ "rustls",
+ "serde",
+ "serde_bytes",
+ "serde_with",
+ "sha1",
+ "sha2",
+ "socket2 0.6.2",
+ "stringprep",
+ "strsim",
+ "take_mut",
+ "thiserror",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "typed-builder",
+ "uuid",
+ "webpki-roots",
+]
+
+[[package]]
+name = "mongodb-internal-macros"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99ceb1a9a1018e470077ec94cf3a8c2d0e6da542b2c05ea95a59a0a627147375"
+dependencies = [
+ "macro_magic",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1311,6 +1878,12 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "nu-ansi-term"
@@ -1400,6 +1973,7 @@ dependencies = [
  "async-stream",
  "axum",
  "base64 0.21.7",
+ "bson",
  "chrono",
  "dotenvy",
  "flate2",
@@ -1409,6 +1983,7 @@ dependencies = [
  "hkdf",
  "hmac",
  "jsonwebtoken",
+ "mongodb",
  "redis",
  "regex",
  "reqwest",
@@ -1431,6 +2006,10 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "opaque-debug"
@@ -1535,6 +2114,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1625,10 +2213,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -1652,6 +2246,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prefix-trie"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -1688,6 +2303,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1706,6 +2333,17 @@ checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1745,6 +2383,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "redis"
@@ -1837,7 +2481,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 0.1.2",
- "system-configuration",
+ "system-configuration 0.5.1",
  "tokio",
  "tokio-native-tls",
  "tokio-util",
@@ -1849,6 +2493,12 @@ dependencies = [
  "web-sys",
  "winreg",
 ]
+
+[[package]]
+name = "resolv-conf"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "rfc6979"
@@ -1904,6 +2554,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version_runtime"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dd18cd2bae1820af0b6ad5e54f4a51d0f3fcc53b05f845675074efcc7af071d"
+dependencies = [
+ "rustc_version",
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1922,6 +2582,7 @@ version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -1982,6 +2643,15 @@ name = "ryu"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -2065,6 +2735,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2090,6 +2770,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -2121,6 +2802,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
+dependencies = [
+ "serde_core",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
 name = "sha1_smol"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2133,7 +2847,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2177,6 +2891,22 @@ name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simple_asn1"
@@ -2245,6 +2975,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2292,7 +3039,18 @@ checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
- "system-configuration-sys",
+ "system-configuration-sys 0.5.0",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.9.4",
+ "system-configuration-sys 0.6.0",
 ]
 
 [[package]]
@@ -2304,6 +3062,34 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
+name = "take_mut"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -2381,6 +3167,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2389,6 +3184,21 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -2457,7 +3267,9 @@ checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]
@@ -2599,6 +3411,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typed-builder"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "398a3a3c918c96de527dc11e6e846cd549d4508030b8a33e1da12789c856b81a"
+dependencies = [
+ "typed-builder-macro",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e48cea23f68d1f78eb7bc092881b6bb88d3d6b5b7e6234f6f9c911da1ffb221"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2615,10 +3447,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "universal-hash"
@@ -2668,6 +3533,7 @@ checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
 dependencies = [
  "getrandom 0.3.4",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -2690,6 +3556,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2709,6 +3585,15 @@ name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
@@ -2773,6 +3658,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
 name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2783,6 +3690,18 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.1",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -2803,6 +3722,30 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2845,6 +3788,17 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
 
 [[package]]
 name = "windows-result"
@@ -3101,12 +4055,103 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.1",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "yoke"

--- a/desktop/Backend-Rust/Cargo.toml
+++ b/desktop/Backend-Rust/Cargo.toml
@@ -59,4 +59,10 @@ redis = { version = "0.25", features = ["tokio-comp", "connection-manager"] }
 # GCP authentication (Vertex AI service account tokens)
 gcp_auth = "0.12"
 
+# MongoDB — self-hosted data store (Phase 2 migration off Firestore). Documents
+# follow the same _id/_p/_k path-faithful model as the Python backend's
+# MongoFirestore shim so both backends share one dataset.
+mongodb = "3"
+bson = { version = "2", features = ["chrono-0_4"] }
+
 # Note: Using Firestore REST API directly instead of gcloud-sdk for compatibility

--- a/desktop/Backend-Rust/src/services/firestore.rs
+++ b/desktop/Backend-Rust/src/services/firestore.rs
@@ -2,7 +2,6 @@
 // Uses Firestore REST API for simplicity and compatibility
 
 use base64::Engine;
-use bson::{doc, Bson, Document};
 use chrono::{DateTime, Utc};
 use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
 use reqwest::Client;
@@ -12,6 +11,7 @@ use sha2::{Digest, Sha256};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
+use super::firestore_shim::{self, ShimRequest, ShimResponse};
 use super::MongoStore;
 use crate::encryption;
 
@@ -87,61 +87,10 @@ pub struct FirestoreService {
     cached_token: Arc<RwLock<Option<CachedToken>>>,
     /// Encryption secret for decrypting user data with enhanced protection level
     encryption_secret: Option<Vec<u8>>,
-    /// MongoDB store — the self-hosted data backend (Phase 2 migration). Functions
-    /// are ported off Firestore REST onto this incrementally; both coexist during
-    /// the migration. Documents use the shared shim format (see mongo_store).
+    /// Self-hosted MongoDB. Firestore REST calls are transparently served from
+    /// here by the shim (see firestore_shim + build_request), so the upstream
+    /// methods run unchanged and nothing actually talks to Google Firestore.
     mongo: MongoStore,
-}
-
-/// Read an optional string field from a MongoDB document.
-fn bson_str(d: &Document, key: &str) -> Option<String> {
-    d.get_str(key).ok().map(String::from)
-}
-
-/// Read an optional UTC timestamp (BSON datetime) from a MongoDB document.
-fn bson_dt(d: &Document, key: &str) -> Option<DateTime<Utc>> {
-    d.get_datetime(key).ok().map(|dt| dt.to_chrono())
-}
-
-/// Read an optional i32, tolerating int32/int64/double storage.
-fn bson_i32(d: &Document, key: &str) -> Option<i32> {
-    match d.get(key) {
-        Some(Bson::Int32(v)) => Some(*v),
-        Some(Bson::Int64(v)) => Some(*v as i32),
-        Some(Bson::Double(v)) => Some(*v as i32),
-        _ => None,
-    }
-}
-
-/// Parse an action-item document (shared shim format) into `ActionItemDB`.
-/// The leaf id is the `_k` reserved field; user fields are top-level.
-fn parse_action_item_bson(d: &Document) -> Option<ActionItemDB> {
-    Some(ActionItemDB {
-        id: d.get_str("_k").ok()?.to_string(),
-        description: d.get_str("description").unwrap_or("").to_string(),
-        completed: d.get_bool("completed").unwrap_or(false),
-        created_at: bson_dt(d, "created_at").unwrap_or_else(Utc::now),
-        updated_at: bson_dt(d, "updated_at"),
-        due_at: bson_dt(d, "due_at"),
-        completed_at: bson_dt(d, "completed_at"),
-        conversation_id: bson_str(d, "conversation_id"),
-        source: bson_str(d, "source"),
-        priority: bson_str(d, "priority"),
-        metadata: bson_str(d, "metadata"),
-        deleted: d.get_bool("deleted").ok(),
-        deleted_by: bson_str(d, "deleted_by"),
-        deleted_at: bson_dt(d, "deleted_at"),
-        deleted_reason: bson_str(d, "deleted_reason"),
-        kept_task_id: bson_str(d, "kept_task_id"),
-        category: bson_str(d, "category"),
-        goal_id: bson_str(d, "goal_id"),
-        relevance_score: bson_i32(d, "relevance_score"),
-        sort_order: bson_i32(d, "sort_order"),
-        indent_level: bson_i32(d, "indent_level"),
-        from_staged: d.get_bool("from_staged").ok(),
-        recurrence_rule: bson_str(d, "recurrence_rule"),
-        recurrence_parent_id: bson_str(d, "recurrence_parent_id"),
-    })
 }
 
 impl FirestoreService {
@@ -153,15 +102,16 @@ impl FirestoreService {
         let client = Client::new();
 
         // Load service account credentials from GOOGLE_APPLICATION_CREDENTIALS
+        // (only used now for the GCE Compute API — Firestore is served from Mongo).
         let credentials = Self::load_credentials()?;
 
-        // Connect to the self-hosted MongoDB (shared with the Python backend).
-        // `with_uri_str` resolves lazily, so this succeeds even if Mongo is
-        // momentarily unreachable; the first query surfaces a connection error.
+        // Self-hosted MongoDB that the shim serves Firestore REST calls from.
+        // `with_uri_str` is lazy, so this succeeds even if Mongo is momentarily
+        // unreachable; the first query surfaces a connection error.
         let mongo_url = std::env::var("MONGODB_URL").unwrap_or_else(|_| "mongodb://localhost:27017".to_string());
         let mongo_db = std::env::var("MONGODB_DB").unwrap_or_else(|_| "omi".to_string());
         let mongo = MongoStore::connect(&mongo_url, &mongo_db).await?;
-        tracing::info!("MongoStore connected (db={})", mongo_db);
+        tracing::info!("MongoStore connected (db={}) — Firestore calls served via shim", mongo_db);
 
         let service = Self {
             client,
@@ -171,11 +121,6 @@ impl FirestoreService {
             encryption_secret,
             mongo,
         };
-
-        // Pre-fetch an access token
-        if let Err(e) = service.get_access_token().await {
-            tracing::warn!("Failed to get initial access token: {}", e);
-        }
 
         Ok(service)
     }
@@ -351,15 +296,25 @@ impl FirestoreService {
     }
 
     /// Build request with auth header
-    async fn build_request(&self, method: reqwest::Method, url: &str) -> Result<reqwest::RequestBuilder, Box<dyn std::error::Error + Send + Sync>> {
-        let mut req = self.client.request(method, url);
+    async fn build_request(&self, method: reqwest::Method, url: &str) -> Result<ShimRequest, Box<dyn std::error::Error + Send + Sync>> {
+        // Firestore REST calls are served from MongoDB by the shim — no Google,
+        // no token. Everything else (GCE Compute, Identity Toolkit) hits the real
+        // network with a service-account bearer token.
+        if firestore_shim::is_firestore_url(url) {
+            return Ok(ShimRequest::Mongo {
+                method: method.as_str().to_string(),
+                url: url.to_string(),
+                body: None,
+                mongo: self.mongo.clone(),
+            });
+        }
         let token = self.get_access_token().await?;
-        req = req.bearer_auth(token);
-        Ok(req)
+        let req = self.client.request(method, url).bearer_auth(token);
+        Ok(ShimRequest::Real(req))
     }
 
     /// Build authenticated request for GCE Compute Engine API (public for agent routes)
-    pub async fn build_compute_request(&self, method: reqwest::Method, url: &str) -> Result<reqwest::RequestBuilder, Box<dyn std::error::Error + Send + Sync>> {
+    pub async fn build_compute_request(&self, method: reqwest::Method, url: &str) -> Result<ShimRequest, Box<dyn std::error::Error + Send + Sync>> {
         self.build_request(method, url).await
     }
 
@@ -367,8 +322,7 @@ impl FirestoreService {
     // LLM USAGE
 
     /// Atomically increment LLM usage counters for a user on a given date.
-    /// MongoDB `$inc` on dotted paths (shared shim format), replacing the
-    /// Firestore commit + FieldTransforms. Document: users/{uid}/llm_usage/{YYYY-MM-DD}.
+    /// Uses Firestore REST commit with FieldTransforms (server-side atomic increments).
     pub async fn record_llm_usage(
         &self,
         uid: &str,
@@ -381,28 +335,49 @@ impl FirestoreService {
         account: &str,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let date_key = Utc::now().format("%Y-%m-%d").to_string();
-        let path = format!("{}/{}/{}/{}", USERS_COLLECTION, uid, LLM_USAGE_SUBCOLLECTION, date_key);
-        // Account-specific prefix (e.g. "desktop_chat_omi"/"desktop_chat_personal"),
-        // plus the rolled-up "desktop_chat" map kept for existing queries.
-        let acct = format!("desktop_chat_{}", account);
-        let mut inc = doc! {
-            "desktop_chat.input_tokens": input,
-            "desktop_chat.output_tokens": output,
-            "desktop_chat.cache_read_tokens": cache_read,
-            "desktop_chat.cache_write_tokens": cache_write,
-            "desktop_chat.total_tokens": total,
-            "desktop_chat.cost_usd": cost,
-            "desktop_chat.call_count": 1i64,
-        };
-        inc.insert(format!("{}.input_tokens", acct), input);
-        inc.insert(format!("{}.output_tokens", acct), output);
-        inc.insert(format!("{}.cache_read_tokens", acct), cache_read);
-        inc.insert(format!("{}.cache_write_tokens", acct), cache_write);
-        inc.insert(format!("{}.total_tokens", acct), total);
-        inc.insert(format!("{}.cost_usd", acct), cost);
-        inc.insert(format!("{}.call_count", acct), 1i64);
-
-        self.mongo.apply(&path, doc! {"$inc": inc}, true).await?;
+        let doc_path = format!(
+            "projects/{}/databases/(default)/documents/{}/{}/{}/{}",
+            self.project_id, USERS_COLLECTION, uid, LLM_USAGE_SUBCOLLECTION, date_key
+        );
+        let commit_url = format!(
+            "https://firestore.googleapis.com/v1/projects/{}/databases/(default)/documents:commit",
+            self.project_id
+        );
+        // Write to account-specific prefix (e.g. "desktop_chat_omi" or "desktop_chat_personal")
+        // Also continue writing to "desktop_chat" for backward compat with existing queries
+        let acct_prefix = format!("desktop_chat_{}", account);
+        let body = json!({
+            "writes": [{
+                "transform": {
+                    "document": doc_path,
+                    "fieldTransforms": [
+                        { "fieldPath": "desktop_chat.input_tokens",       "increment": { "integerValue": input.to_string() } },
+                        { "fieldPath": "desktop_chat.output_tokens",      "increment": { "integerValue": output.to_string() } },
+                        { "fieldPath": "desktop_chat.cache_read_tokens",  "increment": { "integerValue": cache_read.to_string() } },
+                        { "fieldPath": "desktop_chat.cache_write_tokens", "increment": { "integerValue": cache_write.to_string() } },
+                        { "fieldPath": "desktop_chat.total_tokens",       "increment": { "integerValue": total.to_string() } },
+                        { "fieldPath": "desktop_chat.cost_usd",           "increment": { "doubleValue": cost } },
+                        { "fieldPath": "desktop_chat.call_count",         "increment": { "integerValue": "1" } },
+                        { "fieldPath": format!("{}.input_tokens", acct_prefix),       "increment": { "integerValue": input.to_string() } },
+                        { "fieldPath": format!("{}.output_tokens", acct_prefix),      "increment": { "integerValue": output.to_string() } },
+                        { "fieldPath": format!("{}.cache_read_tokens", acct_prefix),  "increment": { "integerValue": cache_read.to_string() } },
+                        { "fieldPath": format!("{}.cache_write_tokens", acct_prefix), "increment": { "integerValue": cache_write.to_string() } },
+                        { "fieldPath": format!("{}.total_tokens", acct_prefix),       "increment": { "integerValue": total.to_string() } },
+                        { "fieldPath": format!("{}.cost_usd", acct_prefix),           "increment": { "doubleValue": cost } },
+                        { "fieldPath": format!("{}.call_count", acct_prefix),         "increment": { "integerValue": "1" } },
+                    ]
+                }
+            }]
+        });
+        let resp = self
+            .build_request(reqwest::Method::POST, &commit_url)
+            .await?
+            .json(&body)
+            .send()
+            .await?;
+        if !resp.status().is_success() {
+            return Err(resp.text().await?.into());
+        }
         Ok(())
     }
 
@@ -1912,71 +1887,250 @@ impl FirestoreService {
         sort_by: Option<&str>,
         include_deleted: Option<bool>,
     ) -> Result<Vec<ActionItemDB>, Box<dyn std::error::Error + Send + Sync>> {
-        // MongoDB (shared shim format). Unlike Firestore, `deleted != true` filters
-        // correctly at the DB level (it also matches docs where the field is
-        // absent), so the Firestore post-query dedup loop is unnecessary here.
-        let parent = format!("{}/{}/{}", USERS_COLLECTION, uid, ACTION_ITEMS_SUBCOLLECTION);
+        let parent = format!("{}/{}/{}", self.base_url(), USERS_COLLECTION, uid);
 
-        let mut filter = Document::new();
+        // Build filters
+        let mut filters: Vec<Value> = Vec::new();
+
         if let Some(completed) = completed_filter {
-            filter.insert("completed", completed);
+            filters.push(json!({
+                "fieldFilter": {
+                    "field": {"fieldPath": "completed"},
+                    "op": "EQUAL",
+                    "value": {"booleanValue": completed}
+                }
+            }));
         }
+
+        // Conversation ID filter
         if let Some(conv_id) = conversation_id {
-            filter.insert("conversation_id", conv_id);
+            filters.push(json!({
+                "fieldFilter": {
+                    "field": {"fieldPath": "conversation_id"},
+                    "op": "EQUAL",
+                    "value": {"stringValue": conv_id}
+                }
+            }));
         }
-        if include_deleted == Some(true) {
-            filter.insert("deleted", true);
+
+        // Date range filters for created_at
+        if let Some(start) = start_date {
+            filters.push(json!({
+                "fieldFilter": {
+                    "field": {"fieldPath": "created_at"},
+                    "op": "GREATER_THAN_OR_EQUAL",
+                    "value": {"timestampValue": start}
+                }
+            }));
+        }
+
+        if let Some(end) = end_date {
+            filters.push(json!({
+                "fieldFilter": {
+                    "field": {"fieldPath": "created_at"},
+                    "op": "LESS_THAN_OR_EQUAL",
+                    "value": {"timestampValue": end}
+                }
+            }));
+        }
+
+        // Date range filters for due_at
+        if let Some(due_start) = due_start_date {
+            filters.push(json!({
+                "fieldFilter": {
+                    "field": {"fieldPath": "due_at"},
+                    "op": "GREATER_THAN_OR_EQUAL",
+                    "value": {"timestampValue": due_start}
+                }
+            }));
+        }
+
+        if let Some(due_end) = due_end_date {
+            filters.push(json!({
+                "fieldFilter": {
+                    "field": {"fieldPath": "due_at"},
+                    "op": "LESS_THAN_OR_EQUAL",
+                    "value": {"timestampValue": due_end}
+                }
+            }));
+        }
+
+        // Build the where clause
+        let where_clause = if filters.is_empty() {
+            None
+        } else if filters.len() == 1 {
+            Some(filters.into_iter().next().unwrap())
         } else {
-            filter.insert("deleted", doc! {"$ne": true});
-        }
-
-        // created_at / due_at range filters (inputs are RFC3339 strings).
-        let parse = |s: &str| DateTime::parse_from_rfc3339(s).ok().map(|dt| bson::DateTime::from_chrono(dt.with_timezone(&Utc)));
-        let mut created_range = Document::new();
-        if let Some(v) = start_date.and_then(parse) {
-            created_range.insert("$gte", v);
-        }
-        if let Some(v) = end_date.and_then(parse) {
-            created_range.insert("$lte", v);
-        }
-        if !created_range.is_empty() {
-            filter.insert("created_at", created_range);
-        }
-        let mut due_range = Document::new();
-        if let Some(v) = due_start_date.and_then(parse) {
-            due_range.insert("$gte", v);
-        }
-        if let Some(v) = due_end_date.and_then(parse) {
-            due_range.insert("$lte", v);
-        }
-        if !due_range.is_empty() {
-            filter.insert("due_at", due_range);
-        }
-
-        // Sort mirrors the Firestore order_by choices.
-        let sort = match sort_by {
-            Some("due_at") => doc! {"due_at": 1, "created_at": -1},
-            Some("priority") => doc! {"priority": -1, "created_at": -1},
-            _ => doc! {"created_at": -1},
+            Some(json!({
+                "compositeFilter": {
+                    "op": "AND",
+                    "filters": filters
+                }
+            }))
         };
 
-        let docs = self
-            .mongo
-            .query(&parent, filter, Some(sort), offset as u64, Some(limit as i64))
-            .await?;
+        // Build order by clause based on sort_by parameter
+        let order_by = match sort_by {
+            Some("due_at") => json!([
+                {"field": {"fieldPath": "due_at"}, "direction": "ASCENDING"},
+                {"field": {"fieldPath": "created_at"}, "direction": "DESCENDING"}
+            ]),
+            Some("priority") => json!([
+                {"field": {"fieldPath": "priority"}, "direction": "DESCENDING"},
+                {"field": {"fieldPath": "created_at"}, "direction": "DESCENDING"}
+            ]),
+            _ => json!([
+                {"field": {"fieldPath": "created_at"}, "direction": "DESCENDING"}
+            ]),
+        };
 
-        let mut action_items: Vec<ActionItemDB> = docs.iter().filter_map(parse_action_item_bson).collect();
+        // Fetch from Firestore in a loop to handle post-query deleted filtering.
+        // Since `deleted` can't be reliably filtered in Firestore (most docs lack the field),
+        // we filter in Rust. But this means a single Firestore page may yield fewer items
+        // than requested after filtering, so we keep fetching until we have enough or Firestore
+        // is exhausted.
+        let mut action_items: Vec<ActionItemDB> = Vec::new();
+        let mut current_offset = offset;
+        let fetch_batch = limit.max(500); // fetch in large batches to minimize round-trips
 
-        // Final ordering parity with the Python app: items WITH due_at first
-        // (ascending), then by created_at descending.
-        action_items.sort_by(|a, b| match (&a.due_at, &b.due_at) {
-            (Some(due_a), Some(due_b)) => due_a.cmp(due_b).then_with(|| b.created_at.cmp(&a.created_at)),
-            (Some(_), None) => std::cmp::Ordering::Less,
-            (None, Some(_)) => std::cmp::Ordering::Greater,
-            (None, None) => b.created_at.cmp(&a.created_at),
+        loop {
+            let mut structured_query = json!({
+                "from": [{"collectionId": ACTION_ITEMS_SUBCOLLECTION}],
+                "orderBy": order_by.clone(),
+                "limit": fetch_batch,
+                "offset": current_offset
+            });
+
+            if let Some(ref where_filter) = where_clause {
+                structured_query["where"] = where_filter.clone();
+            }
+
+            let query = json!({
+                "structuredQuery": structured_query
+            });
+
+            let response = self
+                .build_request(reqwest::Method::POST, &format!("{}:runQuery", parent))
+                .await?
+                .json(&query)
+                .send()
+                .await?;
+
+            if !response.status().is_success() {
+                let error_text = response.text().await?;
+                tracing::error!("Firestore query error for action_items: {}", error_text);
+                return Err(format!("Firestore query error: {}", error_text).into());
+            }
+
+            let results: Vec<Value> = response.json().await?;
+            let fetched_count = results.iter().filter(|doc| doc.get("document").is_some()).count();
+
+            let batch: Vec<ActionItemDB> = results
+                .into_iter()
+                .filter_map(|doc| {
+                    doc.get("document")
+                        .and_then(|d| self.parse_action_item(d).ok())
+                })
+                // Filter based on deleted status
+                .filter(|item| {
+                    if include_deleted == Some(true) {
+                        item.deleted == Some(true)
+                    } else {
+                        item.deleted != Some(true)
+                    }
+                })
+                .collect();
+
+            action_items.extend(batch);
+            current_offset += fetched_count;
+
+            // Stop if Firestore returned fewer than requested (no more data)
+            if fetched_count < fetch_batch {
+                break;
+            }
+
+            // Stop if we have enough items
+            if action_items.len() >= limit {
+                action_items.truncate(limit);
+                break;
+            }
+        }
+
+        // Enrich action items that have conversation_id but no source
+        self.enrich_action_items_with_source(uid, &mut action_items).await;
+
+        // Post-query sort matching Python backend behavior (used by iOS/Flutter app):
+        // 1. Items WITH due_at come first (sorted by due_at ascending)
+        // 2. Items WITHOUT due_at come last
+        // 3. Tie-breaker: created_at descending (newest first)
+        action_items.sort_by(|a, b| {
+            match (&a.due_at, &b.due_at) {
+                (Some(due_a), Some(due_b)) => {
+                    due_a.cmp(due_b).then_with(|| b.created_at.cmp(&a.created_at))
+                }
+                (Some(_), None) => std::cmp::Ordering::Less,
+                (None, Some(_)) => std::cmp::Ordering::Greater,
+                (None, None) => b.created_at.cmp(&a.created_at),
+            }
         });
 
         Ok(action_items)
+    }
+
+    /// Batch fetch conversations and populate source field on action items
+    /// For items with conversation_id but no source, derives source as "transcription:{conversation.source}"
+    async fn enrich_action_items_with_source(&self, uid: &str, action_items: &mut [ActionItemDB]) {
+        use std::collections::{HashMap, HashSet};
+
+        // Collect unique conversation IDs from items that need enrichment
+        // (have conversation_id but no source)
+        let conversation_ids: HashSet<&str> = action_items
+            .iter()
+            .filter(|item| item.source.is_none() && item.conversation_id.is_some())
+            .filter_map(|item| item.conversation_id.as_deref())
+            .collect();
+
+        if conversation_ids.is_empty() {
+            return;
+        }
+
+        tracing::debug!(
+            "Enriching {} action items with source from {} conversations",
+            action_items.iter().filter(|i| i.source.is_none()).count(),
+            conversation_ids.len()
+        );
+
+        // Fetch conversations in parallel (limit to avoid too many concurrent requests)
+        let mut source_map: HashMap<String, String> = HashMap::new();
+
+        // Batch fetch - fetch up to 10 at a time
+        let ids: Vec<&str> = conversation_ids.into_iter().collect();
+        for chunk in ids.chunks(10) {
+            let futures: Vec<_> = chunk
+                .iter()
+                .map(|id| self.get_conversation(uid, id))
+                .collect();
+
+            let results = futures::future::join_all(futures).await;
+
+            for (id, result) in chunk.iter().zip(results) {
+                if let Ok(Some(conv)) = result {
+                    // Format as "transcription:{source}" to match expected values
+                    // e.g., "transcription:omi", "transcription:desktop"
+                    let source_str = format!("transcription:{:?}", conv.source).to_lowercase();
+                    source_map.insert(id.to_string(), source_str);
+                }
+            }
+        }
+
+        // Populate source field on action items that don't have one
+        for item in action_items.iter_mut() {
+            if item.source.is_none() {
+                if let Some(conv_id) = &item.conversation_id {
+                    item.source = source_map.get(conv_id).cloned();
+                }
+            }
+        }
     }
 
     /// Get a single action item by ID
@@ -2265,75 +2419,86 @@ impl FirestoreService {
         recurrence_rule: Option<&str>,
         recurrence_parent_id: Option<&str>,
     ) -> Result<ActionItemDB, Box<dyn std::error::Error + Send + Sync>> {
-        // MongoDB (shared shim format). Matches Python action_items.create_action_item:
-        // random hex id, created_at/updated_at = now (UTC), completed = false.
-        let item_id = uuid::Uuid::new_v4().simple().to_string();
+        let item_id = uuid::Uuid::new_v4().to_string();
         let now = Utc::now();
-        let path = format!("{}/{}/{}/{}", USERS_COLLECTION, uid, ACTION_ITEMS_SUBCOLLECTION, item_id);
 
-        let mut fields = doc! {
-            "description": description,
-            "completed": false,
-            "created_at": bson::DateTime::from_chrono(now),
-            "updated_at": bson::DateTime::from_chrono(now),
-        };
+        let url = format!(
+            "{}/{}/{}/{}/{}",
+            self.base_url(),
+            USERS_COLLECTION,
+            uid,
+            ACTION_ITEMS_SUBCOLLECTION,
+            item_id
+        );
+
+        let mut fields = json!({
+            "description": {"stringValue": description},
+            "completed": {"booleanValue": false},
+            "created_at": {"timestampValue": now.to_rfc3339()},
+            "updated_at": {"timestampValue": now.to_rfc3339()}
+        });
+
         if let Some(due) = due_at {
-            fields.insert("due_at", bson::DateTime::from_chrono(due));
+            fields["due_at"] = json!({"timestampValue": due.to_rfc3339()});
         }
+
         if let Some(src) = source {
-            fields.insert("source", src);
+            fields["source"] = json!({"stringValue": src});
         }
+
         if let Some(pri) = priority {
-            fields.insert("priority", pri);
+            fields["priority"] = json!({"stringValue": pri});
         }
+
         if let Some(meta) = metadata {
-            fields.insert("metadata", meta);
+            fields["metadata"] = json!({"stringValue": meta});
         }
+
         if let Some(cat) = category {
-            fields.insert("category", cat);
+            fields["category"] = json!({"stringValue": cat});
         }
+
         if let Some(score) = relevance_score {
-            fields.insert("relevance_score", score);
+            fields["relevance_score"] = json!({"integerValue": score.to_string()});
         }
+
         if let Some(staged) = from_staged {
-            fields.insert("from_staged", staged);
+            fields["from_staged"] = json!({"booleanValue": staged});
         }
+
         if let Some(rule) = recurrence_rule {
-            fields.insert("recurrence_rule", rule);
+            fields["recurrence_rule"] = json!({"stringValue": rule});
         }
+
         if let Some(pid) = recurrence_parent_id {
-            fields.insert("recurrence_parent_id", pid);
+            fields["recurrence_parent_id"] = json!({"stringValue": pid});
         }
 
-        self.mongo.set(&path, fields).await?;
+        let doc = json!({"fields": fields});
 
-        tracing::info!("Created action item {} for user {} with source={:?}", item_id, uid, source);
-        Ok(ActionItemDB {
-            id: item_id,
-            description: description.to_string(),
-            completed: false,
-            created_at: now,
-            updated_at: Some(now),
-            due_at,
-            completed_at: None,
-            conversation_id: None,
-            source: source.map(String::from),
-            priority: priority.map(String::from),
-            metadata: metadata.map(String::from),
-            deleted: None,
-            deleted_by: None,
-            deleted_at: None,
-            deleted_reason: None,
-            kept_task_id: None,
-            category: category.map(String::from),
-            goal_id: None,
-            relevance_score,
-            sort_order: None,
-            indent_level: None,
-            from_staged,
-            recurrence_rule: recurrence_rule.map(String::from),
-            recurrence_parent_id: recurrence_parent_id.map(String::from),
-        })
+        let response = self
+            .build_request(reqwest::Method::PATCH, &url)
+            .await?
+            .json(&doc)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let error_text = response.text().await?;
+            return Err(format!("Firestore create error: {}", error_text).into());
+        }
+
+        // Parse and return the created document
+        let created_doc: Value = response.json().await?;
+        let action_item = self.parse_action_item(&created_doc)?;
+
+        tracing::info!(
+            "Created action item {} for user {} with source={:?}",
+            item_id,
+            uid,
+            source
+        );
+        Ok(action_item)
     }
 
     /// Batch update relevance scores for multiple action items using Firestore commit API.
@@ -4564,8 +4729,8 @@ impl FirestoreService {
         &self,
         uid: &str,
     ) -> Result<crate::byok::ByokState, Box<dyn std::error::Error + Send + Sync>> {
-        let doc = self.mongo.get(&format!("{}/{}", USERS_COLLECTION, uid)).await?;
-        Ok(parse_byok_state_bson(doc.as_ref()))
+        let doc = self.get_user_document(uid).await?;
+        Ok(parse_byok_state_from_doc(&doc))
     }
 
     /// Read the effective subscription plan for paywall purposes.
@@ -4580,8 +4745,32 @@ impl FirestoreService {
         &self,
         uid: &str,
     ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
-        let doc = self.mongo.get(&format!("{}/{}", USERS_COLLECTION, uid)).await?;
-        Ok(parse_effective_plan_bson(doc.as_ref()))
+        let doc = self.get_user_document(uid).await?;
+        let plan = parse_effective_plan_from_doc(&doc);
+
+        // Log interesting fallback cases for paid plans
+        if let Some(fields) = doc.get("fields") {
+            if let Some(sub_fields) = fields
+                .get("subscription")
+                .and_then(|v| v.get("mapValue"))
+                .and_then(|v| v.get("fields"))
+            {
+                let raw_plan = sub_fields
+                    .get("plan")
+                    .and_then(|v| v.get("stringValue"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("basic");
+
+                if raw_plan != "basic" && raw_plan != "free" && plan == "basic" {
+                    tracing::info!(
+                        "paywall: paid plan '{}' fell back to basic for uid={} (expired or missing period_end)",
+                        raw_plan, uid
+                    );
+                }
+            }
+        }
+
+        Ok(plan)
     }
 
     /// Get user account creation time from Firebase Auth Identity Toolkit REST API.
@@ -6431,65 +6620,195 @@ impl FirestoreService {
     pub async fn get_desktop_releases(
         &self,
     ) -> Result<Vec<crate::routes::updates::ReleaseInfo>, Box<dyn std::error::Error + Send + Sync>> {
-        // Top-level `desktop_releases` collection (shared shim format).
-        let docs = self.mongo.query("desktop_releases", Document::new(), None, 0, None).await?;
-        let mut releases: Vec<crate::routes::updates::ReleaseInfo> =
-            docs.iter().filter_map(parse_release_bson).collect();
-        // Newest first.
+        let url = format!(
+            "{}/desktop_releases",
+            self.base_url()
+        );
+
+        let response = self
+            .build_request(reqwest::Method::GET, &url)
+            .await?
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            // If collection doesn't exist, return empty list
+            if response.status() == reqwest::StatusCode::NOT_FOUND {
+                return Ok(vec![]);
+            }
+            let error_text = response.text().await?;
+            return Err(format!("Firestore error: {}", error_text).into());
+        }
+
+        let data: Value = response.json().await?;
+        let mut releases = Vec::new();
+
+        if let Some(documents) = data.get("documents").and_then(|d| d.as_array()) {
+            for doc in documents {
+                if let Ok(release) = self.parse_release(doc) {
+                    releases.push(release);
+                }
+            }
+        }
+
+        // Sort by build number descending (newest first)
         releases.sort_by(|a, b| b.build_number.cmp(&a.build_number));
+
         Ok(releases)
     }
 
-    /// Create a new desktop release.
+    /// Parse Firestore document to ReleaseInfo
+    fn parse_release(
+        &self,
+        doc: &Value,
+    ) -> Result<crate::routes::updates::ReleaseInfo, Box<dyn std::error::Error + Send + Sync>> {
+        let fields = doc.get("fields").ok_or("Missing fields")?;
+
+        let changelog = if let Some(arr) = fields.get("changelog").and_then(|c| c.get("arrayValue")).and_then(|a| a.get("values")).and_then(|v| v.as_array()) {
+            arr.iter()
+                .filter_map(|v| v.get("stringValue").and_then(|s| s.as_str()))
+                .map(|s| s.to_string())
+                .collect()
+        } else {
+            vec![]
+        };
+
+        // channel: None = unpromoted (staging), Some("stable") = promoted stable
+        let channel = self.parse_string(fields, "channel");
+
+        Ok(crate::routes::updates::ReleaseInfo {
+            version: self.parse_string(fields, "version").unwrap_or_default(),
+            build_number: self.parse_int(fields, "build_number").unwrap_or(0) as u32,
+            download_url: self.parse_string(fields, "download_url").unwrap_or_default(),
+            ed_signature: self.parse_string(fields, "ed_signature").unwrap_or_default(),
+            published_at: self.parse_string(fields, "published_at").unwrap_or_default(),
+            changelog,
+            is_live: self.parse_bool(fields, "is_live").unwrap_or(false),
+            is_critical: self.parse_bool(fields, "is_critical").unwrap_or(false),
+            channel,
+        })
+    }
+
+    /// Create a new desktop release in Firestore
     pub async fn create_desktop_release(
         &self,
         release: &crate::routes::updates::ReleaseInfo,
     ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
         let doc_id = format!("v{}+{}", release.version, release.build_number);
-        let path = format!("desktop_releases/{}", doc_id);
-        // None/empty channel → "staging" (unpromoted default).
-        let channel = match &release.channel {
-            Some(ch) if !ch.is_empty() => ch.clone(),
-            _ => "staging".to_string(),
+
+        let url = format!(
+            "{}/desktop_releases/{}",
+            self.base_url(),
+            doc_id
+        );
+
+        // Build changelog array
+        let changelog_values: Vec<Value> = release.changelog
+            .iter()
+            .map(|s| json!({"stringValue": s}))
+            .collect();
+
+        // Channel field: always a string. None/empty → "staging" (unpromoted default)
+        let channel_value = match &release.channel {
+            Some(ch) if !ch.is_empty() => json!({"stringValue": ch}),
+            _ => json!({"stringValue": "staging"}),
         };
-        let changelog: Vec<Bson> = release.changelog.iter().map(|s| Bson::String(s.clone())).collect();
-        let fields = doc! {
-            "version": &release.version,
-            "build_number": release.build_number as i64,
-            "download_url": &release.download_url,
-            "ed_signature": &release.ed_signature,
-            "published_at": &release.published_at,
-            "changelog": Bson::Array(changelog),
-            "is_live": release.is_live,
-            "is_critical": release.is_critical,
-            "channel": channel,
-        };
-        self.mongo.set(&path, fields).await?;
+
+        let doc = json!({
+            "fields": {
+                "version": {"stringValue": release.version},
+                "build_number": {"integerValue": release.build_number.to_string()},
+                "download_url": {"stringValue": release.download_url},
+                "ed_signature": {"stringValue": release.ed_signature},
+                "published_at": {"stringValue": release.published_at},
+                "changelog": {"arrayValue": {"values": changelog_values}},
+                "is_live": {"booleanValue": release.is_live},
+                "is_critical": {"booleanValue": release.is_critical},
+                "channel": channel_value
+            }
+        });
+
+        let response = self
+            .build_request(reqwest::Method::PATCH, &url)
+            .await?
+            .json(&doc)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let error_text = response.text().await?;
+            return Err(format!("Firestore create error: {}", error_text).into());
+        }
+
         tracing::info!("Created desktop release: {}", doc_id);
         Ok(doc_id)
     }
 
-    /// Promote a desktop release to the next channel: staging → beta → stable.
-    /// Returns (old_channel, new_channel).
+    /// Promote a desktop release to the next channel: staging → beta → stable
+    /// Returns (old_channel, new_channel)
     pub async fn promote_desktop_release(
         &self,
         doc_id: &str,
     ) -> Result<(String, String), Box<dyn std::error::Error + Send + Sync>> {
-        let path = format!("desktop_releases/{}", doc_id);
-        let doc = self
-            .mongo
-            .get(&path)
+        // Fetch the current document
+        let url = format!(
+            "{}/desktop_releases/{}",
+            self.base_url(),
+            doc_id
+        );
+
+        let response = self
+            .build_request(reqwest::Method::GET, &url)
             .await?
-            .ok_or_else(|| format!("Release not found: {}", doc_id))?;
-        let current_channel = doc.get_str("channel").unwrap_or("").to_string();
-        let (old_channel, new_channel) = match current_channel.as_str() {
-            "staging" | "" => ("staging".to_string(), "beta".to_string()),
-            "beta" => ("beta".to_string(), "stable".to_string()),
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let error_text = response.text().await?;
+            return Err(format!("Release not found: {}", error_text).into());
+        }
+
+        let doc: Value = response.json().await?;
+        let fields = doc.get("fields").ok_or("Missing fields in document")?;
+        let current_channel = self.parse_string(fields, "channel").unwrap_or_default();
+
+        // Determine next channel
+        let (old_channel, new_channel_value) = match current_channel.as_str() {
+            "staging" | "" => ("staging".to_string(), json!({"stringValue": "beta"})),
+            "beta" => ("beta".to_string(), json!({"stringValue": "stable"})),
             "stable" => return Err("Release is already on stable channel, cannot promote further".into()),
             other => return Err(format!("Unknown channel '{}', cannot promote", other).into()),
         };
-        self.mongo.apply(&path, doc! {"$set": {"channel": &new_channel}}, false).await?;
+
+        let new_channel = new_channel_value.get("stringValue").and_then(|v| v.as_str()).unwrap().to_string();
+
+        // PATCH only the channel field
+        let patch_url = format!(
+            "{}/desktop_releases/{}?updateMask.fieldPaths=channel",
+            self.base_url(),
+            doc_id
+        );
+
+        let patch_doc = json!({
+            "fields": {
+                "channel": new_channel_value
+            }
+        });
+
+        let response = self
+            .build_request(reqwest::Method::PATCH, &patch_url)
+            .await?
+            .json(&patch_doc)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let error_text = response.text().await?;
+            return Err(format!("Failed to update channel: {}", error_text).into());
+        }
+
         tracing::info!("Promoted release {}: {} → {}", doc_id, old_channel, new_channel);
+
         Ok((old_channel, new_channel))
     }
 
@@ -8269,7 +8588,6 @@ impl FirestoreService {
                     .json(&total_query)
                     .send()
                     .await
-                    .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { Box::new(e) })
             },
             async {
                 self.build_request(reqwest::Method::POST, &agg_url)
@@ -8277,11 +8595,10 @@ impl FirestoreService {
                     .json(&completed_query)
                     .send()
                     .await
-                    .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { Box::new(e) })
             }
         );
 
-        let parse_count = |response: reqwest::Response| async move {
+        let parse_count = |response: ShimResponse| async move {
             if !response.status().is_success() {
                 let error_text = response.text().await?;
                 return Err(format!("Firestore aggregation query error: {}", error_text).into());
@@ -9328,37 +9645,94 @@ impl FirestoreService {
         &self,
         uid: &str,
     ) -> Result<Option<crate::models::agent::AgentVm>, Box<dyn std::error::Error + Send + Sync>> {
-        // MongoDB user doc; `agentVm` is a plain nested document.
-        let doc = match self.mongo.get(&format!("{}/{}", USERS_COLLECTION, uid)).await? {
-            Some(d) => d,
-            None => return Ok(None),
-        };
-        let vm = match doc.get_document("agentVm").ok() {
-            Some(v) => v,
-            None => return Ok(None),
-        };
-        let vm_name = vm.get_str("vmName").unwrap_or("").to_string();
+        let doc = self.get_user_document(uid).await?;
+        let empty = json!({});
+        let fields = doc.get("fields").unwrap_or(&empty);
+
+        let agent_vm = fields.get("agentVm");
+        if agent_vm.is_none() {
+            return Ok(None);
+        }
+
+        let map_value = agent_vm
+            .and_then(|v| v.get("mapValue"))
+            .and_then(|v| v.get("fields"));
+
+        if map_value.is_none() {
+            return Ok(None);
+        }
+
+        let f = map_value.unwrap();
+
+        let vm_name = f
+            .get("vmName")
+            .and_then(|v| v.get("stringValue"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+
         if vm_name.is_empty() {
             return Ok(None);
         }
-        let status = match vm.get_str("status").unwrap_or("provisioning") {
+
+        let zone = f
+            .get("zone")
+            .and_then(|v| v.get("stringValue"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("us-central1-a")
+            .to_string();
+
+        let ip = f
+            .get("ip")
+            .and_then(|v| v.get("stringValue"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        let status_str = f
+            .get("status")
+            .and_then(|v| v.get("stringValue"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("provisioning");
+
+        let status = match status_str {
             "ready" => crate::models::agent::AgentVmStatus::Ready,
             "stopped" => crate::models::agent::AgentVmStatus::Stopped,
             "error" => crate::models::agent::AgentVmStatus::Error,
             _ => crate::models::agent::AgentVmStatus::Provisioning,
         };
+
+        let auth_token = f
+            .get("authToken")
+            .and_then(|v| v.get("stringValue"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+
+        let created_at = f
+            .get("createdAt")
+            .and_then(|v| v.get("stringValue"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+
+        let last_query_at = f
+            .get("lastQueryAt")
+            .and_then(|v| v.get("stringValue"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
         Ok(Some(crate::models::agent::AgentVm {
             vm_name,
-            zone: vm.get_str("zone").unwrap_or("us-central1-a").to_string(),
-            ip: vm.get_str("ip").ok().map(String::from),
+            zone,
+            ip,
             status,
-            auth_token: vm.get_str("authToken").unwrap_or("").to_string(),
-            created_at: vm.get_str("createdAt").unwrap_or("").to_string(),
-            last_query_at: vm.get_str("lastQueryAt").ok().map(String::from),
+            auth_token,
+            created_at,
+            last_query_at,
         }))
     }
 
-    /// Set agent VM info on a user's document (`agentVm` nested field).
+    /// Set agent VM info on a user's document
     pub async fn set_agent_vm(
         &self,
         uid: &str,
@@ -9369,37 +9743,49 @@ impl FirestoreService {
         auth_token: &str,
         created_at: &str,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        let mut vm = doc! {
-            "vmName": vm_name,
-            "zone": zone,
-            "status": status.to_string(),
-            "authToken": auth_token,
-            "createdAt": created_at,
-        };
+        let mut vm_fields = json!({
+            "vmName": {"stringValue": vm_name},
+            "zone": {"stringValue": zone},
+            "status": {"stringValue": status.to_string()},
+            "authToken": {"stringValue": auth_token},
+            "createdAt": {"stringValue": created_at}
+        });
+
         if let Some(ip_val) = ip {
-            vm.insert("ip", ip_val);
+            vm_fields.as_object_mut().unwrap().insert(
+                "ip".to_string(),
+                json!({"stringValue": ip_val}),
+            );
         }
-        self.mongo
-            .apply(&format!("{}/{}", USERS_COLLECTION, uid), doc! {"$set": {"agentVm": vm}}, true)
-            .await?;
-        Ok(())
+
+        let fields = json!({
+            "agentVm": {
+                "mapValue": {
+                    "fields": vm_fields
+                }
+            }
+        });
+
+        self.update_user_fields(uid, fields, &["agentVm"]).await
     }
 
-    /// Delete the `agentVm` field from a user's document (GCE VM gone).
-    pub async fn delete_agent_vm(&self, uid: &str) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        self.mongo
-            .apply(&format!("{}/{}", USERS_COLLECTION, uid), doc! {"$unset": {"agentVm": ""}}, false)
-            .await?;
-        Ok(())
+    /// Delete the agentVm field from a user's document.
+    /// Used when the GCE VM no longer exists in GCP.
+    pub async fn delete_agent_vm(
+        &self,
+        uid: &str,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        // Omitting agentVm from the body while including it in the update mask
+        // causes Firestore to delete the field.
+        self.update_user_fields(uid, json!({}), &["agentVm"]).await
     }
 
     // =========================================================================
     // SCREEN ACTIVITY
     // =========================================================================
 
-    /// Upsert screen activity rows to MongoDB users/{uid}/screen_activity/{id}.
-    /// (Python's screen_activity.py is still Firestore — a known straggler; both
-    /// use the shared shim collection `screen_activity`, so they align once it's migrated.)
+    /// Batch write screen activity rows to Firestore users/{uid}/screen_activity/{id}.
+    /// Uses Firestore commit API for batch writes (max 500 per commit).
     pub async fn upsert_screen_activity(
         &self,
         uid: &str,
@@ -9408,24 +9794,66 @@ impl FirestoreService {
         if rows.is_empty() {
             return Ok(0);
         }
+
         let mut written = 0;
-        for row in rows {
-            let path = format!(
-                "{}/{}/{}/{}",
-                USERS_COLLECTION, uid, SCREEN_ACTIVITY_SUBCOLLECTION, row.id
+
+        for chunk in rows.chunks(500) {
+            let writes: Vec<Value> = chunk
+                .iter()
+                .map(|row| {
+                    let doc_name = format!(
+                        "projects/{}/databases/(default)/documents/{}/{}/{}/{}",
+                        self.project_id,
+                        USERS_COLLECTION,
+                        uid,
+                        SCREEN_ACTIVITY_SUBCOLLECTION,
+                        row.id
+                    );
+
+                    // Truncate OCR text to 1000 chars
+                    let ocr_truncated: String = row.ocr_text.chars().take(1000).collect();
+
+                    json!({
+                        "update": {
+                            "name": doc_name,
+                            "fields": {
+                                "timestamp": {"stringValue": &row.timestamp},
+                                "appName": {"stringValue": &row.app_name},
+                                "windowTitle": {"stringValue": &row.window_title},
+                                "ocrText": {"stringValue": ocr_truncated},
+                            }
+                        }
+                    })
+                })
+                .collect();
+
+            let commit_url = format!(
+                "https://firestore.googleapis.com/v1/projects/{}/databases/(default)/documents:commit",
+                self.project_id
             );
-            // Truncate OCR text to 1000 chars (parity with the Firestore version).
-            let ocr_truncated: String = row.ocr_text.chars().take(1000).collect();
-            let fields = doc! {
-                "timestamp": &row.timestamp,
-                "appName": &row.app_name,
-                "windowTitle": &row.window_title,
-                "ocrText": ocr_truncated,
-            };
-            self.mongo.set(&path, fields).await?;
-            written += 1;
+
+            let body = json!({ "writes": writes });
+
+            let response = self
+                .build_request(reqwest::Method::POST, &commit_url)
+                .await?
+                .json(&body)
+                .send()
+                .await?;
+
+            if !response.status().is_success() {
+                let error_text = response.text().await?;
+                return Err(format!("Firestore screen_activity batch commit error: {}", error_text).into());
+            }
+
+            written += chunk.len();
         }
-        tracing::info!("Screen activity Mongo write uid={} count={}", uid, written);
+
+        tracing::info!(
+            "Screen activity Firestore write uid={} count={}",
+            uid,
+            written
+        );
         Ok(written)
     }
 }
@@ -9549,77 +9977,6 @@ fn parse_effective_plan_from_doc(doc: &Value) -> String {
     }
 }
 
-/// Parse BYOK state from a MongoDB user document (shared shim format).
-/// `byok` is a plain nested document: { active, fingerprints: {provider: fp}, last_seen_at }.
-/// Returns `ByokState::default()` (inactive) when absent.
-fn parse_byok_state_bson(doc: Option<&Document>) -> crate::byok::ByokState {
-    let byok = match doc.and_then(|d| d.get_document("byok").ok()) {
-        Some(b) => b,
-        None => return crate::byok::ByokState::default(),
-    };
-    let active = byok.get_bool("active").unwrap_or(false);
-    let mut fingerprints = std::collections::HashMap::new();
-    if let Ok(fp) = byok.get_document("fingerprints") {
-        for (provider, val) in fp {
-            if let Bson::String(s) = val {
-                fingerprints.insert(provider.clone(), s.clone());
-            }
-        }
-    }
-    let last_seen_at = byok.get_datetime("last_seen_at").ok().map(|dt| dt.to_chrono());
-    crate::byok::ByokState {
-        active,
-        fingerprints,
-        last_seen_at,
-    }
-}
-
-/// Parse the effective subscription plan from a MongoDB user document.
-/// `subscription` is a plain nested document: { plan, current_period_end (unix secs), ... }.
-/// Returns "basic" when missing/expired/free (fail-open), matching the Firestore parser.
-fn parse_effective_plan_bson(doc: Option<&Document>) -> String {
-    let sub = match doc.and_then(|d| d.get_document("subscription").ok()) {
-        Some(s) => s,
-        None => return "basic".to_string(),
-    };
-    let mut plan = sub.get_str("plan").unwrap_or("basic").to_string();
-    if plan == "free" {
-        plan = "basic".to_string();
-    }
-    if plan == "basic" {
-        return plan;
-    }
-    let period_end = match sub.get("current_period_end") {
-        Some(Bson::Int64(v)) => Some(*v),
-        Some(Bson::Int32(v)) => Some(*v as i64),
-        Some(Bson::Double(v)) => Some(*v as i64),
-        _ => None,
-    };
-    match period_end {
-        Some(pe) if pe >= chrono::Utc::now().timestamp() => plan,
-        _ => "basic".to_string(),
-    }
-}
-
-/// Parse a desktop_releases document (shared shim format) into `ReleaseInfo`.
-fn parse_release_bson(d: &Document) -> Option<crate::routes::updates::ReleaseInfo> {
-    let changelog = d
-        .get_array("changelog")
-        .map(|arr| arr.iter().filter_map(|v| v.as_str().map(String::from)).collect())
-        .unwrap_or_default();
-    Some(crate::routes::updates::ReleaseInfo {
-        version: d.get_str("version").unwrap_or("").to_string(),
-        build_number: bson_i32(d, "build_number").unwrap_or(0) as u32,
-        download_url: d.get_str("download_url").unwrap_or("").to_string(),
-        ed_signature: d.get_str("ed_signature").unwrap_or("").to_string(),
-        published_at: d.get_str("published_at").unwrap_or("").to_string(),
-        changelog,
-        is_live: d.get_bool("is_live").unwrap_or(false),
-        is_critical: d.get_bool("is_critical").unwrap_or(false),
-        channel: d.get_str("channel").ok().map(String::from),
-    })
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -9630,161 +9987,6 @@ mod tests {
         assert_eq!(id.len(), 20);
         assert_eq!(id, document_id_from_seed("test content"));
         assert_ne!(id, document_id_from_seed("different content"));
-    }
-
-    // --- MongoDB (shim-format) parser tests ---
-
-    #[test]
-    fn bson_byok_active_with_fingerprints() {
-        let d = doc! { "byok": { "active": true, "fingerprints": { "openai": "abc", "anthropic": "xyz" } } };
-        let st = parse_byok_state_bson(Some(&d));
-        assert!(st.active);
-        assert_eq!(st.fingerprints.get("openai").unwrap(), "abc");
-        assert_eq!(st.fingerprints.get("anthropic").unwrap(), "xyz");
-    }
-
-    #[test]
-    fn bson_byok_absent_is_inactive_default() {
-        assert!(!parse_byok_state_bson(None).active);
-        assert!(!parse_byok_state_bson(Some(&doc! {"foo": 1})).active);
-    }
-
-    #[test]
-    fn bson_effective_plan_cases() {
-        assert_eq!(parse_effective_plan_bson(None), "basic");
-        assert_eq!(parse_effective_plan_bson(Some(&doc! {})), "basic");
-        assert_eq!(parse_effective_plan_bson(Some(&doc! {"subscription": {"plan": "free"}})), "basic");
-        assert_eq!(parse_effective_plan_bson(Some(&doc! {"subscription": {"plan": "basic"}})), "basic");
-        let future = chrono::Utc::now().timestamp() + 86400;
-        assert_eq!(
-            parse_effective_plan_bson(Some(&doc! {"subscription": {"plan": "unlimited", "current_period_end": future}})),
-            "unlimited"
-        );
-        let past = chrono::Utc::now().timestamp() - 86400;
-        assert_eq!(
-            parse_effective_plan_bson(Some(&doc! {"subscription": {"plan": "unlimited", "current_period_end": past}})),
-            "basic"
-        );
-        // Paid plan without a period end fails closed to basic.
-        assert_eq!(parse_effective_plan_bson(Some(&doc! {"subscription": {"plan": "unlimited"}})), "basic");
-    }
-
-    /// End-to-end user-doc (byok/subscription) + llm_usage round-trip against a
-    /// real MongoDB. Ignored by default — run with
-    /// `MONGO_TEST_URL=mongodb://localhost:27018 cargo test -- --ignored user_doc_and_usage_mongo_roundtrip`.
-    #[tokio::test]
-    #[ignore]
-    async fn user_doc_and_usage_mongo_roundtrip() {
-        let url = std::env::var("MONGO_TEST_URL").expect("set MONGO_TEST_URL");
-        std::env::set_var("MONGODB_URL", &url);
-        std::env::set_var("MONGODB_DB", "omi_user_test");
-        let fs = FirestoreService::new("test-project".to_string(), None).await.unwrap();
-        let uid = "u_user_test";
-        let upath = format!("users/{}", uid);
-        fs.mongo.delete(&upath).await.unwrap();
-
-        // Seed a user doc the way Python stores it (plain nested byok/subscription).
-        let future = chrono::Utc::now().timestamp() + 86400;
-        fs.mongo
-            .set(
-                &upath,
-                doc! {
-                    "byok": {"active": true, "fingerprints": {"openai": "fp123"}},
-                    "subscription": {"plan": "unlimited", "current_period_end": future},
-                },
-            )
-            .await
-            .unwrap();
-
-        let byok = fs.get_user_byok_state(uid).await.unwrap();
-        assert!(byok.active);
-        assert_eq!(byok.fingerprints.get("openai").unwrap(), "fp123");
-        assert_eq!(fs.get_user_effective_plan(uid).await.unwrap(), "unlimited");
-
-        // record_llm_usage uses $inc — two calls accumulate.
-        fs.record_llm_usage(uid, 10, 5, 0, 0, 15, 0.002, "omi").await.unwrap();
-        fs.record_llm_usage(uid, 20, 7, 0, 0, 27, 0.003, "omi").await.unwrap();
-        let date_key = chrono::Utc::now().format("%Y-%m-%d").to_string();
-        let usage_path = format!("users/{}/llm_usage/{}", uid, date_key);
-        let usage = fs.mongo.get(&usage_path).await.unwrap().unwrap();
-        let dc = usage.get_document("desktop_chat").unwrap();
-        assert_eq!(dc.get_i64("input_tokens").unwrap(), 30);
-        assert_eq!(dc.get_i64("call_count").unwrap(), 2);
-        let acct = usage.get_document("desktop_chat_omi").unwrap();
-        assert_eq!(acct.get_i64("input_tokens").unwrap(), 30);
-
-        fs.mongo.delete(&upath).await.unwrap();
-        fs.mongo.delete(&usage_path).await.unwrap();
-    }
-
-    /// End-to-end action_items round-trip against a real MongoDB (shared shim
-    /// format). Ignored by default (CI has no Mongo); run with
-    /// `MONGO_TEST_URL=mongodb://localhost:27018 cargo test -- --ignored action_items_mongo_roundtrip`.
-    #[tokio::test]
-    #[ignore]
-    async fn action_items_mongo_roundtrip() {
-        let url = std::env::var("MONGO_TEST_URL").expect("set MONGO_TEST_URL");
-        std::env::set_var("MONGODB_URL", &url);
-        std::env::set_var("MONGODB_DB", "omi_at_test");
-        let fs = FirestoreService::new("test-project".to_string(), None)
-            .await
-            .expect("FirestoreService::new");
-        let uid = "u_at_test";
-
-        let created = fs
-            .create_action_item(
-                uid,
-                "buy milk",
-                None,
-                Some("sentry_feedback"),
-                Some("high"),
-                None,
-                Some("work"),
-                Some(5),
-                None,
-                None,
-                None,
-            )
-            .await
-            .expect("create");
-        assert_eq!(created.description, "buy milk");
-        assert!(!created.completed);
-
-        // Read it back through the Mongo query path.
-        let items = fs
-            .get_action_items(uid, 50, 0, None, None, None, None, None, None, None, None)
-            .await
-            .expect("get");
-        let found = items.iter().find(|i| i.id == created.id).expect("created item present");
-        assert_eq!(found.description, "buy milk");
-        assert_eq!(found.source.as_deref(), Some("sentry_feedback"));
-        assert_eq!(found.priority.as_deref(), Some("high"));
-        assert_eq!(found.category.as_deref(), Some("work"));
-        assert_eq!(found.relevance_score, Some(5));
-        assert!(!found.completed);
-
-        // completed=true filter must exclude our incomplete item.
-        let completed = fs
-            .get_action_items(uid, 50, 0, Some(true), None, None, None, None, None, None, None)
-            .await
-            .expect("get completed");
-        assert!(!completed.iter().any(|i| i.id == created.id));
-
-        // Stored doc uses the shim format (collection `action_items`, _k = leaf id).
-        let raw = fs
-            .mongo
-            .get(&format!("users/{}/action_items/{}", uid, created.id))
-            .await
-            .unwrap()
-            .expect("raw doc");
-        assert_eq!(raw.get_str("_k").unwrap(), created.id);
-        assert_eq!(raw.get_str("_p").unwrap(), format!("users/{}/action_items", uid));
-
-        // cleanup
-        fs.mongo
-            .delete(&format!("users/{}/action_items/{}", uid, created.id))
-            .await
-            .unwrap();
     }
 
     // --- Firestore BYOK state parsing tests ---
@@ -10009,81 +10211,87 @@ mod tests {
         assert_eq!(parse_effective_plan_from_doc(&doc), "enterprise");
     }
 
-    /// End-to-end desktop_releases + agent_vm + screen_activity round-trip against
-    /// a real MongoDB. Ignored by default — run with
-    /// `MONGO_TEST_URL=mongodb://localhost:27018 cargo test -- --ignored releases_and_agent_vm_mongo_roundtrip`.
+    /// End-to-end: drive the upstream FirestoreService methods THROUGH the shim
+    /// (Firestore REST -> MongoDB) against a real Mongo. This is the proof the
+    /// shim approach works without changing any method. Run with
+    /// `MONGO_TEST_URL=mongodb://localhost:27018 cargo test -- --ignored shim_end_to_end_via_methods`.
     #[tokio::test]
     #[ignore]
-    async fn releases_and_agent_vm_mongo_roundtrip() {
+    async fn shim_end_to_end_via_methods() {
         let url = std::env::var("MONGO_TEST_URL").expect("set MONGO_TEST_URL");
         std::env::set_var("MONGODB_URL", &url);
-        std::env::set_var("MONGODB_DB", "omi_rel_test");
+        std::env::set_var("MONGODB_DB", "omi_e2e_test");
         let fs = FirestoreService::new("test-project".to_string(), None).await.unwrap();
+        let uid = "u_e2e";
 
-        // desktop_releases: create -> get -> promote
-        let rel = crate::routes::updates::ReleaseInfo {
-            version: "1.2.3".to_string(),
-            build_number: 99,
-            download_url: "https://x/y.zip".to_string(),
-            ed_signature: "sig".to_string(),
-            published_at: "2026-06-08T00:00:00Z".to_string(),
-            changelog: vec!["a".to_string(), "b".to_string()],
-            is_live: true,
-            is_critical: false,
-            channel: None,
-        };
-        let id = fs.create_desktop_release(&rel).await.unwrap();
-        assert_eq!(id, "v1.2.3+99");
-        let list = fs.get_desktop_releases().await.unwrap();
-        let got = list.iter().find(|r| r.build_number == 99).expect("release present");
-        assert_eq!(got.version, "1.2.3");
-        assert_eq!(got.changelog, vec!["a".to_string(), "b".to_string()]);
-        assert_eq!(got.channel.as_deref(), Some("staging")); // defaulted on create
-        let (old, new) = fs.promote_desktop_release(&id).await.unwrap();
-        assert_eq!((old.as_str(), new.as_str()), ("staging", "beta"));
-        fs.mongo.delete(&format!("desktop_releases/{}", id)).await.unwrap();
-
-        // agent_vm: set -> get -> delete
-        let uid = "u_vm_test";
+        // Seed a user doc (byok + subscription) directly, as the Python backend would.
+        let seed = crate::services::mongo_store::MongoStore::connect(&url, "omi_e2e_test").await.unwrap();
         let upath = format!("users/{}", uid);
-        fs.mongo.delete(&upath).await.unwrap();
-        assert!(fs.get_agent_vm(uid).await.unwrap().is_none());
-        fs.set_agent_vm(
-            uid,
-            "vm-1",
-            "us-central1-a",
-            Some("10.0.0.1"),
-            crate::models::agent::AgentVmStatus::Ready,
-            "tok",
-            "2026-06-08T00:00:00Z",
+        let _ = seed.delete(&upath).await;
+        let future = chrono::Utc::now().timestamp() + 86400;
+        seed.set(
+            &upath,
+            bson::doc! {
+                "byok": {"active": true, "fingerprints": {"openai": "fp1"}},
+                "subscription": {"plan": "unlimited", "current_period_end": future},
+            },
         )
         .await
         .unwrap();
-        let vm = fs.get_agent_vm(uid).await.unwrap().expect("vm present");
-        assert_eq!(vm.vm_name, "vm-1");
-        assert_eq!(vm.ip.as_deref(), Some("10.0.0.1"));
-        assert_eq!(vm.status, crate::models::agent::AgentVmStatus::Ready);
+
+        // byok + subscription read through the unchanged upstream methods (via shim).
+        let byok = fs.get_user_byok_state(uid).await.unwrap();
+        assert!(byok.active);
+        assert_eq!(byok.fingerprints.get("openai").unwrap(), "fp1");
+        assert_eq!(fs.get_user_effective_plan(uid).await.unwrap(), "unlimited");
+
+        // action_items create + query through the methods.
+        let created = fs
+            .create_action_item(uid, "buy milk", None, Some("sentry_feedback"), Some("high"), None, Some("work"), Some(5), None, None, None)
+            .await
+            .unwrap();
+        let items = fs
+            .get_action_items(uid, 50, 0, None, None, None, None, None, None, None, None)
+            .await
+            .unwrap();
+        let found = items.iter().find(|i| i.id == created.id).expect("created item present");
+        assert_eq!(found.description, "buy milk");
+        assert_eq!(found.source.as_deref(), Some("sentry_feedback"));
+        // landed in the shared shim collection with _p set
+        let raw = seed.get(&format!("users/{}/action_items/{}", uid, created.id)).await.unwrap().unwrap();
+        assert_eq!(raw.get_str("_p").unwrap(), format!("users/{}/action_items", uid));
+
+        // llm usage: two increments through record_llm_usage, summed via get_total_llm_cost.
+        let dk = chrono::Utc::now().format("%Y-%m-%d").to_string();
+        let _ = seed.delete(&format!("users/{}/llm_usage/{}", uid, dk)).await;
+        fs.record_llm_usage(uid, 10, 5, 0, 0, 15, 0.25, "omi").await.unwrap();
+        fs.record_llm_usage(uid, 20, 7, 0, 0, 27, 0.25, "omi").await.unwrap();
+        let total = fs.get_total_llm_cost(uid).await.unwrap();
+        assert!((total - 0.5).abs() < 1e-9, "total cost was {}", total);
+
+        // agent_vm set/get/delete through the methods.
+        fs.set_agent_vm(uid, "vm-1", "us-central1-a", Some("10.0.0.1"), crate::models::agent::AgentVmStatus::Ready, "tok", "2026-06-08T00:00:00Z")
+            .await
+            .unwrap();
+        assert_eq!(fs.get_agent_vm(uid).await.unwrap().expect("vm").vm_name, "vm-1");
         fs.delete_agent_vm(uid).await.unwrap();
         assert!(fs.get_agent_vm(uid).await.unwrap().is_none());
 
-        // screen_activity: upsert
-        let rows = vec![crate::models::screen_activity::ScreenActivityRow {
-            id: 1717000000,
-            timestamp: "2026-06-08 10:00:00.000".to_string(),
-            app_name: "Safari".to_string(),
-            window_title: "Inbox".to_string(),
-            ocr_text: "hello".to_string(),
-            embedding: None,
-        }];
-        assert_eq!(fs.upsert_screen_activity(uid, &rows).await.unwrap(), 1);
-        let sa = fs
-            .mongo
-            .get(&format!("users/{}/screen_activity/{}", uid, 1717000000i64))
-            .await
-            .unwrap()
-            .unwrap();
-        assert_eq!(sa.get_str("appName").unwrap(), "Safari");
-        fs.mongo.delete(&format!("users/{}/screen_activity/{}", uid, 1717000000i64)).await.unwrap();
-        fs.mongo.delete(&upath).await.unwrap();
+        // desktop_releases create/get/promote through the methods.
+        let rel = crate::routes::updates::ReleaseInfo {
+            version: "1.2.3".to_string(), build_number: 99, download_url: "u".to_string(),
+            ed_signature: "s".to_string(), published_at: "2026-06-08T00:00:00Z".to_string(),
+            changelog: vec!["a".to_string()], is_live: true, is_critical: false, channel: None,
+        };
+        let id = fs.create_desktop_release(&rel).await.unwrap();
+        assert!(fs.get_desktop_releases().await.unwrap().iter().any(|r| r.build_number == 99 && r.version == "1.2.3"));
+        let (o, n) = fs.promote_desktop_release(&id).await.unwrap();
+        assert_eq!((o.as_str(), n.as_str()), ("staging", "beta"));
+
+        // cleanup
+        let _ = seed.delete(&upath).await;
+        let _ = seed.delete(&format!("users/{}/action_items/{}", uid, created.id)).await;
+        let _ = seed.delete(&format!("users/{}/llm_usage/{}", uid, dk)).await;
+        let _ = seed.delete(&format!("desktop_releases/{}", id)).await;
     }
 }

--- a/desktop/Backend-Rust/src/services/firestore.rs
+++ b/desktop/Backend-Rust/src/services/firestore.rs
@@ -367,7 +367,8 @@ impl FirestoreService {
     // LLM USAGE
 
     /// Atomically increment LLM usage counters for a user on a given date.
-    /// Uses Firestore REST commit with FieldTransforms (server-side atomic increments).
+    /// MongoDB `$inc` on dotted paths (shared shim format), replacing the
+    /// Firestore commit + FieldTransforms. Document: users/{uid}/llm_usage/{YYYY-MM-DD}.
     pub async fn record_llm_usage(
         &self,
         uid: &str,
@@ -380,49 +381,28 @@ impl FirestoreService {
         account: &str,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let date_key = Utc::now().format("%Y-%m-%d").to_string();
-        let doc_path = format!(
-            "projects/{}/databases/(default)/documents/{}/{}/{}/{}",
-            self.project_id, USERS_COLLECTION, uid, LLM_USAGE_SUBCOLLECTION, date_key
-        );
-        let commit_url = format!(
-            "https://firestore.googleapis.com/v1/projects/{}/databases/(default)/documents:commit",
-            self.project_id
-        );
-        // Write to account-specific prefix (e.g. "desktop_chat_omi" or "desktop_chat_personal")
-        // Also continue writing to "desktop_chat" for backward compat with existing queries
-        let acct_prefix = format!("desktop_chat_{}", account);
-        let body = json!({
-            "writes": [{
-                "transform": {
-                    "document": doc_path,
-                    "fieldTransforms": [
-                        { "fieldPath": "desktop_chat.input_tokens",       "increment": { "integerValue": input.to_string() } },
-                        { "fieldPath": "desktop_chat.output_tokens",      "increment": { "integerValue": output.to_string() } },
-                        { "fieldPath": "desktop_chat.cache_read_tokens",  "increment": { "integerValue": cache_read.to_string() } },
-                        { "fieldPath": "desktop_chat.cache_write_tokens", "increment": { "integerValue": cache_write.to_string() } },
-                        { "fieldPath": "desktop_chat.total_tokens",       "increment": { "integerValue": total.to_string() } },
-                        { "fieldPath": "desktop_chat.cost_usd",           "increment": { "doubleValue": cost } },
-                        { "fieldPath": "desktop_chat.call_count",         "increment": { "integerValue": "1" } },
-                        { "fieldPath": format!("{}.input_tokens", acct_prefix),       "increment": { "integerValue": input.to_string() } },
-                        { "fieldPath": format!("{}.output_tokens", acct_prefix),      "increment": { "integerValue": output.to_string() } },
-                        { "fieldPath": format!("{}.cache_read_tokens", acct_prefix),  "increment": { "integerValue": cache_read.to_string() } },
-                        { "fieldPath": format!("{}.cache_write_tokens", acct_prefix), "increment": { "integerValue": cache_write.to_string() } },
-                        { "fieldPath": format!("{}.total_tokens", acct_prefix),       "increment": { "integerValue": total.to_string() } },
-                        { "fieldPath": format!("{}.cost_usd", acct_prefix),           "increment": { "doubleValue": cost } },
-                        { "fieldPath": format!("{}.call_count", acct_prefix),         "increment": { "integerValue": "1" } },
-                    ]
-                }
-            }]
-        });
-        let resp = self
-            .build_request(reqwest::Method::POST, &commit_url)
-            .await?
-            .json(&body)
-            .send()
-            .await?;
-        if !resp.status().is_success() {
-            return Err(resp.text().await?.into());
-        }
+        let path = format!("{}/{}/{}/{}", USERS_COLLECTION, uid, LLM_USAGE_SUBCOLLECTION, date_key);
+        // Account-specific prefix (e.g. "desktop_chat_omi"/"desktop_chat_personal"),
+        // plus the rolled-up "desktop_chat" map kept for existing queries.
+        let acct = format!("desktop_chat_{}", account);
+        let mut inc = doc! {
+            "desktop_chat.input_tokens": input,
+            "desktop_chat.output_tokens": output,
+            "desktop_chat.cache_read_tokens": cache_read,
+            "desktop_chat.cache_write_tokens": cache_write,
+            "desktop_chat.total_tokens": total,
+            "desktop_chat.cost_usd": cost,
+            "desktop_chat.call_count": 1i64,
+        };
+        inc.insert(format!("{}.input_tokens", acct), input);
+        inc.insert(format!("{}.output_tokens", acct), output);
+        inc.insert(format!("{}.cache_read_tokens", acct), cache_read);
+        inc.insert(format!("{}.cache_write_tokens", acct), cache_write);
+        inc.insert(format!("{}.total_tokens", acct), total);
+        inc.insert(format!("{}.cost_usd", acct), cost);
+        inc.insert(format!("{}.call_count", acct), 1i64);
+
+        self.mongo.apply(&path, doc! {"$inc": inc}, true).await?;
         Ok(())
     }
 
@@ -4584,8 +4564,8 @@ impl FirestoreService {
         &self,
         uid: &str,
     ) -> Result<crate::byok::ByokState, Box<dyn std::error::Error + Send + Sync>> {
-        let doc = self.get_user_document(uid).await?;
-        Ok(parse_byok_state_from_doc(&doc))
+        let doc = self.mongo.get(&format!("{}/{}", USERS_COLLECTION, uid)).await?;
+        Ok(parse_byok_state_bson(doc.as_ref()))
     }
 
     /// Read the effective subscription plan for paywall purposes.
@@ -4600,32 +4580,8 @@ impl FirestoreService {
         &self,
         uid: &str,
     ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
-        let doc = self.get_user_document(uid).await?;
-        let plan = parse_effective_plan_from_doc(&doc);
-
-        // Log interesting fallback cases for paid plans
-        if let Some(fields) = doc.get("fields") {
-            if let Some(sub_fields) = fields
-                .get("subscription")
-                .and_then(|v| v.get("mapValue"))
-                .and_then(|v| v.get("fields"))
-            {
-                let raw_plan = sub_fields
-                    .get("plan")
-                    .and_then(|v| v.get("stringValue"))
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("basic");
-
-                if raw_plan != "basic" && raw_plan != "free" && plan == "basic" {
-                    tracing::info!(
-                        "paywall: paid plan '{}' fell back to basic for uid={} (expired or missing period_end)",
-                        raw_plan, uid
-                    );
-                }
-            }
-        }
-
-        Ok(plan)
+        let doc = self.mongo.get(&format!("{}/{}", USERS_COLLECTION, uid)).await?;
+        Ok(parse_effective_plan_bson(doc.as_ref()))
     }
 
     /// Get user account creation time from Firebase Auth Identity Toolkit REST API.
@@ -9834,6 +9790,58 @@ fn parse_effective_plan_from_doc(doc: &Value) -> String {
     }
 }
 
+/// Parse BYOK state from a MongoDB user document (shared shim format).
+/// `byok` is a plain nested document: { active, fingerprints: {provider: fp}, last_seen_at }.
+/// Returns `ByokState::default()` (inactive) when absent.
+fn parse_byok_state_bson(doc: Option<&Document>) -> crate::byok::ByokState {
+    let byok = match doc.and_then(|d| d.get_document("byok").ok()) {
+        Some(b) => b,
+        None => return crate::byok::ByokState::default(),
+    };
+    let active = byok.get_bool("active").unwrap_or(false);
+    let mut fingerprints = std::collections::HashMap::new();
+    if let Ok(fp) = byok.get_document("fingerprints") {
+        for (provider, val) in fp {
+            if let Bson::String(s) = val {
+                fingerprints.insert(provider.clone(), s.clone());
+            }
+        }
+    }
+    let last_seen_at = byok.get_datetime("last_seen_at").ok().map(|dt| dt.to_chrono());
+    crate::byok::ByokState {
+        active,
+        fingerprints,
+        last_seen_at,
+    }
+}
+
+/// Parse the effective subscription plan from a MongoDB user document.
+/// `subscription` is a plain nested document: { plan, current_period_end (unix secs), ... }.
+/// Returns "basic" when missing/expired/free (fail-open), matching the Firestore parser.
+fn parse_effective_plan_bson(doc: Option<&Document>) -> String {
+    let sub = match doc.and_then(|d| d.get_document("subscription").ok()) {
+        Some(s) => s,
+        None => return "basic".to_string(),
+    };
+    let mut plan = sub.get_str("plan").unwrap_or("basic").to_string();
+    if plan == "free" {
+        plan = "basic".to_string();
+    }
+    if plan == "basic" {
+        return plan;
+    }
+    let period_end = match sub.get("current_period_end") {
+        Some(Bson::Int64(v)) => Some(*v),
+        Some(Bson::Int32(v)) => Some(*v as i64),
+        Some(Bson::Double(v)) => Some(*v as i64),
+        _ => None,
+    };
+    match period_end {
+        Some(pe) if pe >= chrono::Utc::now().timestamp() => plan,
+        _ => "basic".to_string(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -9844,6 +9852,91 @@ mod tests {
         assert_eq!(id.len(), 20);
         assert_eq!(id, document_id_from_seed("test content"));
         assert_ne!(id, document_id_from_seed("different content"));
+    }
+
+    // --- MongoDB (shim-format) parser tests ---
+
+    #[test]
+    fn bson_byok_active_with_fingerprints() {
+        let d = doc! { "byok": { "active": true, "fingerprints": { "openai": "abc", "anthropic": "xyz" } } };
+        let st = parse_byok_state_bson(Some(&d));
+        assert!(st.active);
+        assert_eq!(st.fingerprints.get("openai").unwrap(), "abc");
+        assert_eq!(st.fingerprints.get("anthropic").unwrap(), "xyz");
+    }
+
+    #[test]
+    fn bson_byok_absent_is_inactive_default() {
+        assert!(!parse_byok_state_bson(None).active);
+        assert!(!parse_byok_state_bson(Some(&doc! {"foo": 1})).active);
+    }
+
+    #[test]
+    fn bson_effective_plan_cases() {
+        assert_eq!(parse_effective_plan_bson(None), "basic");
+        assert_eq!(parse_effective_plan_bson(Some(&doc! {})), "basic");
+        assert_eq!(parse_effective_plan_bson(Some(&doc! {"subscription": {"plan": "free"}})), "basic");
+        assert_eq!(parse_effective_plan_bson(Some(&doc! {"subscription": {"plan": "basic"}})), "basic");
+        let future = chrono::Utc::now().timestamp() + 86400;
+        assert_eq!(
+            parse_effective_plan_bson(Some(&doc! {"subscription": {"plan": "unlimited", "current_period_end": future}})),
+            "unlimited"
+        );
+        let past = chrono::Utc::now().timestamp() - 86400;
+        assert_eq!(
+            parse_effective_plan_bson(Some(&doc! {"subscription": {"plan": "unlimited", "current_period_end": past}})),
+            "basic"
+        );
+        // Paid plan without a period end fails closed to basic.
+        assert_eq!(parse_effective_plan_bson(Some(&doc! {"subscription": {"plan": "unlimited"}})), "basic");
+    }
+
+    /// End-to-end user-doc (byok/subscription) + llm_usage round-trip against a
+    /// real MongoDB. Ignored by default — run with
+    /// `MONGO_TEST_URL=mongodb://localhost:27018 cargo test -- --ignored user_doc_and_usage_mongo_roundtrip`.
+    #[tokio::test]
+    #[ignore]
+    async fn user_doc_and_usage_mongo_roundtrip() {
+        let url = std::env::var("MONGO_TEST_URL").expect("set MONGO_TEST_URL");
+        std::env::set_var("MONGODB_URL", &url);
+        std::env::set_var("MONGODB_DB", "omi_user_test");
+        let fs = FirestoreService::new("test-project".to_string(), None).await.unwrap();
+        let uid = "u_user_test";
+        let upath = format!("users/{}", uid);
+        fs.mongo.delete(&upath).await.unwrap();
+
+        // Seed a user doc the way Python stores it (plain nested byok/subscription).
+        let future = chrono::Utc::now().timestamp() + 86400;
+        fs.mongo
+            .set(
+                &upath,
+                doc! {
+                    "byok": {"active": true, "fingerprints": {"openai": "fp123"}},
+                    "subscription": {"plan": "unlimited", "current_period_end": future},
+                },
+            )
+            .await
+            .unwrap();
+
+        let byok = fs.get_user_byok_state(uid).await.unwrap();
+        assert!(byok.active);
+        assert_eq!(byok.fingerprints.get("openai").unwrap(), "fp123");
+        assert_eq!(fs.get_user_effective_plan(uid).await.unwrap(), "unlimited");
+
+        // record_llm_usage uses $inc — two calls accumulate.
+        fs.record_llm_usage(uid, 10, 5, 0, 0, 15, 0.002, "omi").await.unwrap();
+        fs.record_llm_usage(uid, 20, 7, 0, 0, 27, 0.003, "omi").await.unwrap();
+        let date_key = chrono::Utc::now().format("%Y-%m-%d").to_string();
+        let usage_path = format!("users/{}/llm_usage/{}", uid, date_key);
+        let usage = fs.mongo.get(&usage_path).await.unwrap().unwrap();
+        let dc = usage.get_document("desktop_chat").unwrap();
+        assert_eq!(dc.get_i64("input_tokens").unwrap(), 30);
+        assert_eq!(dc.get_i64("call_count").unwrap(), 2);
+        let acct = usage.get_document("desktop_chat_omi").unwrap();
+        assert_eq!(acct.get_i64("input_tokens").unwrap(), 30);
+
+        fs.mongo.delete(&upath).await.unwrap();
+        fs.mongo.delete(&usage_path).await.unwrap();
     }
 
     /// End-to-end action_items round-trip against a real MongoDB (shared shim

--- a/desktop/Backend-Rust/src/services/firestore.rs
+++ b/desktop/Backend-Rust/src/services/firestore.rs
@@ -2,6 +2,7 @@
 // Uses Firestore REST API for simplicity and compatibility
 
 use base64::Engine;
+use bson::{doc, Bson, Document};
 use chrono::{DateTime, Utc};
 use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
 use reqwest::Client;
@@ -11,6 +12,7 @@ use sha2::{Digest, Sha256};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
+use super::MongoStore;
 use crate::encryption;
 
 use crate::models::{
@@ -85,6 +87,61 @@ pub struct FirestoreService {
     cached_token: Arc<RwLock<Option<CachedToken>>>,
     /// Encryption secret for decrypting user data with enhanced protection level
     encryption_secret: Option<Vec<u8>>,
+    /// MongoDB store — the self-hosted data backend (Phase 2 migration). Functions
+    /// are ported off Firestore REST onto this incrementally; both coexist during
+    /// the migration. Documents use the shared shim format (see mongo_store).
+    mongo: MongoStore,
+}
+
+/// Read an optional string field from a MongoDB document.
+fn bson_str(d: &Document, key: &str) -> Option<String> {
+    d.get_str(key).ok().map(String::from)
+}
+
+/// Read an optional UTC timestamp (BSON datetime) from a MongoDB document.
+fn bson_dt(d: &Document, key: &str) -> Option<DateTime<Utc>> {
+    d.get_datetime(key).ok().map(|dt| dt.to_chrono())
+}
+
+/// Read an optional i32, tolerating int32/int64/double storage.
+fn bson_i32(d: &Document, key: &str) -> Option<i32> {
+    match d.get(key) {
+        Some(Bson::Int32(v)) => Some(*v),
+        Some(Bson::Int64(v)) => Some(*v as i32),
+        Some(Bson::Double(v)) => Some(*v as i32),
+        _ => None,
+    }
+}
+
+/// Parse an action-item document (shared shim format) into `ActionItemDB`.
+/// The leaf id is the `_k` reserved field; user fields are top-level.
+fn parse_action_item_bson(d: &Document) -> Option<ActionItemDB> {
+    Some(ActionItemDB {
+        id: d.get_str("_k").ok()?.to_string(),
+        description: d.get_str("description").unwrap_or("").to_string(),
+        completed: d.get_bool("completed").unwrap_or(false),
+        created_at: bson_dt(d, "created_at").unwrap_or_else(Utc::now),
+        updated_at: bson_dt(d, "updated_at"),
+        due_at: bson_dt(d, "due_at"),
+        completed_at: bson_dt(d, "completed_at"),
+        conversation_id: bson_str(d, "conversation_id"),
+        source: bson_str(d, "source"),
+        priority: bson_str(d, "priority"),
+        metadata: bson_str(d, "metadata"),
+        deleted: d.get_bool("deleted").ok(),
+        deleted_by: bson_str(d, "deleted_by"),
+        deleted_at: bson_dt(d, "deleted_at"),
+        deleted_reason: bson_str(d, "deleted_reason"),
+        kept_task_id: bson_str(d, "kept_task_id"),
+        category: bson_str(d, "category"),
+        goal_id: bson_str(d, "goal_id"),
+        relevance_score: bson_i32(d, "relevance_score"),
+        sort_order: bson_i32(d, "sort_order"),
+        indent_level: bson_i32(d, "indent_level"),
+        from_staged: d.get_bool("from_staged").ok(),
+        recurrence_rule: bson_str(d, "recurrence_rule"),
+        recurrence_parent_id: bson_str(d, "recurrence_parent_id"),
+    })
 }
 
 impl FirestoreService {
@@ -98,12 +155,21 @@ impl FirestoreService {
         // Load service account credentials from GOOGLE_APPLICATION_CREDENTIALS
         let credentials = Self::load_credentials()?;
 
+        // Connect to the self-hosted MongoDB (shared with the Python backend).
+        // `with_uri_str` resolves lazily, so this succeeds even if Mongo is
+        // momentarily unreachable; the first query surfaces a connection error.
+        let mongo_url = std::env::var("MONGODB_URL").unwrap_or_else(|_| "mongodb://localhost:27017".to_string());
+        let mongo_db = std::env::var("MONGODB_DB").unwrap_or_else(|_| "omi".to_string());
+        let mongo = MongoStore::connect(&mongo_url, &mongo_db).await?;
+        tracing::info!("MongoStore connected (db={})", mongo_db);
+
         let service = Self {
             client,
             project_id,
             credentials,
             cached_token: Arc::new(RwLock::new(None)),
             encryption_secret,
+            mongo,
         };
 
         // Pre-fetch an access token
@@ -1866,250 +1932,71 @@ impl FirestoreService {
         sort_by: Option<&str>,
         include_deleted: Option<bool>,
     ) -> Result<Vec<ActionItemDB>, Box<dyn std::error::Error + Send + Sync>> {
-        let parent = format!("{}/{}/{}", self.base_url(), USERS_COLLECTION, uid);
+        // MongoDB (shared shim format). Unlike Firestore, `deleted != true` filters
+        // correctly at the DB level (it also matches docs where the field is
+        // absent), so the Firestore post-query dedup loop is unnecessary here.
+        let parent = format!("{}/{}/{}", USERS_COLLECTION, uid, ACTION_ITEMS_SUBCOLLECTION);
 
-        // Build filters
-        let mut filters: Vec<Value> = Vec::new();
-
+        let mut filter = Document::new();
         if let Some(completed) = completed_filter {
-            filters.push(json!({
-                "fieldFilter": {
-                    "field": {"fieldPath": "completed"},
-                    "op": "EQUAL",
-                    "value": {"booleanValue": completed}
-                }
-            }));
+            filter.insert("completed", completed);
         }
-
-        // Conversation ID filter
         if let Some(conv_id) = conversation_id {
-            filters.push(json!({
-                "fieldFilter": {
-                    "field": {"fieldPath": "conversation_id"},
-                    "op": "EQUAL",
-                    "value": {"stringValue": conv_id}
-                }
-            }));
+            filter.insert("conversation_id", conv_id);
         }
-
-        // Date range filters for created_at
-        if let Some(start) = start_date {
-            filters.push(json!({
-                "fieldFilter": {
-                    "field": {"fieldPath": "created_at"},
-                    "op": "GREATER_THAN_OR_EQUAL",
-                    "value": {"timestampValue": start}
-                }
-            }));
-        }
-
-        if let Some(end) = end_date {
-            filters.push(json!({
-                "fieldFilter": {
-                    "field": {"fieldPath": "created_at"},
-                    "op": "LESS_THAN_OR_EQUAL",
-                    "value": {"timestampValue": end}
-                }
-            }));
-        }
-
-        // Date range filters for due_at
-        if let Some(due_start) = due_start_date {
-            filters.push(json!({
-                "fieldFilter": {
-                    "field": {"fieldPath": "due_at"},
-                    "op": "GREATER_THAN_OR_EQUAL",
-                    "value": {"timestampValue": due_start}
-                }
-            }));
-        }
-
-        if let Some(due_end) = due_end_date {
-            filters.push(json!({
-                "fieldFilter": {
-                    "field": {"fieldPath": "due_at"},
-                    "op": "LESS_THAN_OR_EQUAL",
-                    "value": {"timestampValue": due_end}
-                }
-            }));
-        }
-
-        // Build the where clause
-        let where_clause = if filters.is_empty() {
-            None
-        } else if filters.len() == 1 {
-            Some(filters.into_iter().next().unwrap())
+        if include_deleted == Some(true) {
+            filter.insert("deleted", true);
         } else {
-            Some(json!({
-                "compositeFilter": {
-                    "op": "AND",
-                    "filters": filters
-                }
-            }))
-        };
-
-        // Build order by clause based on sort_by parameter
-        let order_by = match sort_by {
-            Some("due_at") => json!([
-                {"field": {"fieldPath": "due_at"}, "direction": "ASCENDING"},
-                {"field": {"fieldPath": "created_at"}, "direction": "DESCENDING"}
-            ]),
-            Some("priority") => json!([
-                {"field": {"fieldPath": "priority"}, "direction": "DESCENDING"},
-                {"field": {"fieldPath": "created_at"}, "direction": "DESCENDING"}
-            ]),
-            _ => json!([
-                {"field": {"fieldPath": "created_at"}, "direction": "DESCENDING"}
-            ]),
-        };
-
-        // Fetch from Firestore in a loop to handle post-query deleted filtering.
-        // Since `deleted` can't be reliably filtered in Firestore (most docs lack the field),
-        // we filter in Rust. But this means a single Firestore page may yield fewer items
-        // than requested after filtering, so we keep fetching until we have enough or Firestore
-        // is exhausted.
-        let mut action_items: Vec<ActionItemDB> = Vec::new();
-        let mut current_offset = offset;
-        let fetch_batch = limit.max(500); // fetch in large batches to minimize round-trips
-
-        loop {
-            let mut structured_query = json!({
-                "from": [{"collectionId": ACTION_ITEMS_SUBCOLLECTION}],
-                "orderBy": order_by.clone(),
-                "limit": fetch_batch,
-                "offset": current_offset
-            });
-
-            if let Some(ref where_filter) = where_clause {
-                structured_query["where"] = where_filter.clone();
-            }
-
-            let query = json!({
-                "structuredQuery": structured_query
-            });
-
-            let response = self
-                .build_request(reqwest::Method::POST, &format!("{}:runQuery", parent))
-                .await?
-                .json(&query)
-                .send()
-                .await?;
-
-            if !response.status().is_success() {
-                let error_text = response.text().await?;
-                tracing::error!("Firestore query error for action_items: {}", error_text);
-                return Err(format!("Firestore query error: {}", error_text).into());
-            }
-
-            let results: Vec<Value> = response.json().await?;
-            let fetched_count = results.iter().filter(|doc| doc.get("document").is_some()).count();
-
-            let batch: Vec<ActionItemDB> = results
-                .into_iter()
-                .filter_map(|doc| {
-                    doc.get("document")
-                        .and_then(|d| self.parse_action_item(d).ok())
-                })
-                // Filter based on deleted status
-                .filter(|item| {
-                    if include_deleted == Some(true) {
-                        item.deleted == Some(true)
-                    } else {
-                        item.deleted != Some(true)
-                    }
-                })
-                .collect();
-
-            action_items.extend(batch);
-            current_offset += fetched_count;
-
-            // Stop if Firestore returned fewer than requested (no more data)
-            if fetched_count < fetch_batch {
-                break;
-            }
-
-            // Stop if we have enough items
-            if action_items.len() >= limit {
-                action_items.truncate(limit);
-                break;
-            }
+            filter.insert("deleted", doc! {"$ne": true});
         }
 
-        // Enrich action items that have conversation_id but no source
-        self.enrich_action_items_with_source(uid, &mut action_items).await;
+        // created_at / due_at range filters (inputs are RFC3339 strings).
+        let parse = |s: &str| DateTime::parse_from_rfc3339(s).ok().map(|dt| bson::DateTime::from_chrono(dt.with_timezone(&Utc)));
+        let mut created_range = Document::new();
+        if let Some(v) = start_date.and_then(parse) {
+            created_range.insert("$gte", v);
+        }
+        if let Some(v) = end_date.and_then(parse) {
+            created_range.insert("$lte", v);
+        }
+        if !created_range.is_empty() {
+            filter.insert("created_at", created_range);
+        }
+        let mut due_range = Document::new();
+        if let Some(v) = due_start_date.and_then(parse) {
+            due_range.insert("$gte", v);
+        }
+        if let Some(v) = due_end_date.and_then(parse) {
+            due_range.insert("$lte", v);
+        }
+        if !due_range.is_empty() {
+            filter.insert("due_at", due_range);
+        }
 
-        // Post-query sort matching Python backend behavior (used by iOS/Flutter app):
-        // 1. Items WITH due_at come first (sorted by due_at ascending)
-        // 2. Items WITHOUT due_at come last
-        // 3. Tie-breaker: created_at descending (newest first)
-        action_items.sort_by(|a, b| {
-            match (&a.due_at, &b.due_at) {
-                (Some(due_a), Some(due_b)) => {
-                    due_a.cmp(due_b).then_with(|| b.created_at.cmp(&a.created_at))
-                }
-                (Some(_), None) => std::cmp::Ordering::Less,
-                (None, Some(_)) => std::cmp::Ordering::Greater,
-                (None, None) => b.created_at.cmp(&a.created_at),
-            }
+        // Sort mirrors the Firestore order_by choices.
+        let sort = match sort_by {
+            Some("due_at") => doc! {"due_at": 1, "created_at": -1},
+            Some("priority") => doc! {"priority": -1, "created_at": -1},
+            _ => doc! {"created_at": -1},
+        };
+
+        let docs = self
+            .mongo
+            .query(&parent, filter, Some(sort), offset as u64, Some(limit as i64))
+            .await?;
+
+        let mut action_items: Vec<ActionItemDB> = docs.iter().filter_map(parse_action_item_bson).collect();
+
+        // Final ordering parity with the Python app: items WITH due_at first
+        // (ascending), then by created_at descending.
+        action_items.sort_by(|a, b| match (&a.due_at, &b.due_at) {
+            (Some(due_a), Some(due_b)) => due_a.cmp(due_b).then_with(|| b.created_at.cmp(&a.created_at)),
+            (Some(_), None) => std::cmp::Ordering::Less,
+            (None, Some(_)) => std::cmp::Ordering::Greater,
+            (None, None) => b.created_at.cmp(&a.created_at),
         });
 
         Ok(action_items)
-    }
-
-    /// Batch fetch conversations and populate source field on action items
-    /// For items with conversation_id but no source, derives source as "transcription:{conversation.source}"
-    async fn enrich_action_items_with_source(&self, uid: &str, action_items: &mut [ActionItemDB]) {
-        use std::collections::{HashMap, HashSet};
-
-        // Collect unique conversation IDs from items that need enrichment
-        // (have conversation_id but no source)
-        let conversation_ids: HashSet<&str> = action_items
-            .iter()
-            .filter(|item| item.source.is_none() && item.conversation_id.is_some())
-            .filter_map(|item| item.conversation_id.as_deref())
-            .collect();
-
-        if conversation_ids.is_empty() {
-            return;
-        }
-
-        tracing::debug!(
-            "Enriching {} action items with source from {} conversations",
-            action_items.iter().filter(|i| i.source.is_none()).count(),
-            conversation_ids.len()
-        );
-
-        // Fetch conversations in parallel (limit to avoid too many concurrent requests)
-        let mut source_map: HashMap<String, String> = HashMap::new();
-
-        // Batch fetch - fetch up to 10 at a time
-        let ids: Vec<&str> = conversation_ids.into_iter().collect();
-        for chunk in ids.chunks(10) {
-            let futures: Vec<_> = chunk
-                .iter()
-                .map(|id| self.get_conversation(uid, id))
-                .collect();
-
-            let results = futures::future::join_all(futures).await;
-
-            for (id, result) in chunk.iter().zip(results) {
-                if let Ok(Some(conv)) = result {
-                    // Format as "transcription:{source}" to match expected values
-                    // e.g., "transcription:omi", "transcription:desktop"
-                    let source_str = format!("transcription:{:?}", conv.source).to_lowercase();
-                    source_map.insert(id.to_string(), source_str);
-                }
-            }
-        }
-
-        // Populate source field on action items that don't have one
-        for item in action_items.iter_mut() {
-            if item.source.is_none() {
-                if let Some(conv_id) = &item.conversation_id {
-                    item.source = source_map.get(conv_id).cloned();
-                }
-            }
-        }
     }
 
     /// Get a single action item by ID
@@ -2398,86 +2285,75 @@ impl FirestoreService {
         recurrence_rule: Option<&str>,
         recurrence_parent_id: Option<&str>,
     ) -> Result<ActionItemDB, Box<dyn std::error::Error + Send + Sync>> {
-        let item_id = uuid::Uuid::new_v4().to_string();
+        // MongoDB (shared shim format). Matches Python action_items.create_action_item:
+        // random hex id, created_at/updated_at = now (UTC), completed = false.
+        let item_id = uuid::Uuid::new_v4().simple().to_string();
         let now = Utc::now();
+        let path = format!("{}/{}/{}/{}", USERS_COLLECTION, uid, ACTION_ITEMS_SUBCOLLECTION, item_id);
 
-        let url = format!(
-            "{}/{}/{}/{}/{}",
-            self.base_url(),
-            USERS_COLLECTION,
-            uid,
-            ACTION_ITEMS_SUBCOLLECTION,
-            item_id
-        );
-
-        let mut fields = json!({
-            "description": {"stringValue": description},
-            "completed": {"booleanValue": false},
-            "created_at": {"timestampValue": now.to_rfc3339()},
-            "updated_at": {"timestampValue": now.to_rfc3339()}
-        });
-
+        let mut fields = doc! {
+            "description": description,
+            "completed": false,
+            "created_at": bson::DateTime::from_chrono(now),
+            "updated_at": bson::DateTime::from_chrono(now),
+        };
         if let Some(due) = due_at {
-            fields["due_at"] = json!({"timestampValue": due.to_rfc3339()});
+            fields.insert("due_at", bson::DateTime::from_chrono(due));
         }
-
         if let Some(src) = source {
-            fields["source"] = json!({"stringValue": src});
+            fields.insert("source", src);
         }
-
         if let Some(pri) = priority {
-            fields["priority"] = json!({"stringValue": pri});
+            fields.insert("priority", pri);
         }
-
         if let Some(meta) = metadata {
-            fields["metadata"] = json!({"stringValue": meta});
+            fields.insert("metadata", meta);
         }
-
         if let Some(cat) = category {
-            fields["category"] = json!({"stringValue": cat});
+            fields.insert("category", cat);
         }
-
         if let Some(score) = relevance_score {
-            fields["relevance_score"] = json!({"integerValue": score.to_string()});
+            fields.insert("relevance_score", score);
         }
-
         if let Some(staged) = from_staged {
-            fields["from_staged"] = json!({"booleanValue": staged});
+            fields.insert("from_staged", staged);
         }
-
         if let Some(rule) = recurrence_rule {
-            fields["recurrence_rule"] = json!({"stringValue": rule});
+            fields.insert("recurrence_rule", rule);
         }
-
         if let Some(pid) = recurrence_parent_id {
-            fields["recurrence_parent_id"] = json!({"stringValue": pid});
+            fields.insert("recurrence_parent_id", pid);
         }
 
-        let doc = json!({"fields": fields});
+        self.mongo.set(&path, fields).await?;
 
-        let response = self
-            .build_request(reqwest::Method::PATCH, &url)
-            .await?
-            .json(&doc)
-            .send()
-            .await?;
-
-        if !response.status().is_success() {
-            let error_text = response.text().await?;
-            return Err(format!("Firestore create error: {}", error_text).into());
-        }
-
-        // Parse and return the created document
-        let created_doc: Value = response.json().await?;
-        let action_item = self.parse_action_item(&created_doc)?;
-
-        tracing::info!(
-            "Created action item {} for user {} with source={:?}",
-            item_id,
-            uid,
-            source
-        );
-        Ok(action_item)
+        tracing::info!("Created action item {} for user {} with source={:?}", item_id, uid, source);
+        Ok(ActionItemDB {
+            id: item_id,
+            description: description.to_string(),
+            completed: false,
+            created_at: now,
+            updated_at: Some(now),
+            due_at,
+            completed_at: None,
+            conversation_id: None,
+            source: source.map(String::from),
+            priority: priority.map(String::from),
+            metadata: metadata.map(String::from),
+            deleted: None,
+            deleted_by: None,
+            deleted_at: None,
+            deleted_reason: None,
+            kept_task_id: None,
+            category: category.map(String::from),
+            goal_id: None,
+            relevance_score,
+            sort_order: None,
+            indent_level: None,
+            from_staged,
+            recurrence_rule: recurrence_rule.map(String::from),
+            recurrence_parent_id: recurrence_parent_id.map(String::from),
+        })
     }
 
     /// Batch update relevance scores for multiple action items using Firestore commit API.
@@ -9968,6 +9844,76 @@ mod tests {
         assert_eq!(id.len(), 20);
         assert_eq!(id, document_id_from_seed("test content"));
         assert_ne!(id, document_id_from_seed("different content"));
+    }
+
+    /// End-to-end action_items round-trip against a real MongoDB (shared shim
+    /// format). Ignored by default (CI has no Mongo); run with
+    /// `MONGO_TEST_URL=mongodb://localhost:27018 cargo test -- --ignored action_items_mongo_roundtrip`.
+    #[tokio::test]
+    #[ignore]
+    async fn action_items_mongo_roundtrip() {
+        let url = std::env::var("MONGO_TEST_URL").expect("set MONGO_TEST_URL");
+        std::env::set_var("MONGODB_URL", &url);
+        std::env::set_var("MONGODB_DB", "omi_at_test");
+        let fs = FirestoreService::new("test-project".to_string(), None)
+            .await
+            .expect("FirestoreService::new");
+        let uid = "u_at_test";
+
+        let created = fs
+            .create_action_item(
+                uid,
+                "buy milk",
+                None,
+                Some("sentry_feedback"),
+                Some("high"),
+                None,
+                Some("work"),
+                Some(5),
+                None,
+                None,
+                None,
+            )
+            .await
+            .expect("create");
+        assert_eq!(created.description, "buy milk");
+        assert!(!created.completed);
+
+        // Read it back through the Mongo query path.
+        let items = fs
+            .get_action_items(uid, 50, 0, None, None, None, None, None, None, None, None)
+            .await
+            .expect("get");
+        let found = items.iter().find(|i| i.id == created.id).expect("created item present");
+        assert_eq!(found.description, "buy milk");
+        assert_eq!(found.source.as_deref(), Some("sentry_feedback"));
+        assert_eq!(found.priority.as_deref(), Some("high"));
+        assert_eq!(found.category.as_deref(), Some("work"));
+        assert_eq!(found.relevance_score, Some(5));
+        assert!(!found.completed);
+
+        // completed=true filter must exclude our incomplete item.
+        let completed = fs
+            .get_action_items(uid, 50, 0, Some(true), None, None, None, None, None, None, None)
+            .await
+            .expect("get completed");
+        assert!(!completed.iter().any(|i| i.id == created.id));
+
+        // Stored doc uses the shim format (collection `action_items`, _k = leaf id).
+        let raw = fs
+            .mongo
+            .get(&format!("users/{}/action_items/{}", uid, created.id))
+            .await
+            .unwrap()
+            .expect("raw doc");
+        assert_eq!(raw.get_str("_k").unwrap(), created.id);
+        assert_eq!(raw.get_str("_p").unwrap(), format!("users/{}/action_items", uid));
+
+        // cleanup
+        fs.mongo
+            .delete(&format!("users/{}/action_items/{}", uid, created.id))
+            .await
+            .unwrap();
     }
 
     // --- Firestore BYOK state parsing tests ---

--- a/desktop/Backend-Rust/src/services/firestore.rs
+++ b/desktop/Backend-Rust/src/services/firestore.rs
@@ -6431,195 +6431,65 @@ impl FirestoreService {
     pub async fn get_desktop_releases(
         &self,
     ) -> Result<Vec<crate::routes::updates::ReleaseInfo>, Box<dyn std::error::Error + Send + Sync>> {
-        let url = format!(
-            "{}/desktop_releases",
-            self.base_url()
-        );
-
-        let response = self
-            .build_request(reqwest::Method::GET, &url)
-            .await?
-            .send()
-            .await?;
-
-        if !response.status().is_success() {
-            // If collection doesn't exist, return empty list
-            if response.status() == reqwest::StatusCode::NOT_FOUND {
-                return Ok(vec![]);
-            }
-            let error_text = response.text().await?;
-            return Err(format!("Firestore error: {}", error_text).into());
-        }
-
-        let data: Value = response.json().await?;
-        let mut releases = Vec::new();
-
-        if let Some(documents) = data.get("documents").and_then(|d| d.as_array()) {
-            for doc in documents {
-                if let Ok(release) = self.parse_release(doc) {
-                    releases.push(release);
-                }
-            }
-        }
-
-        // Sort by build number descending (newest first)
+        // Top-level `desktop_releases` collection (shared shim format).
+        let docs = self.mongo.query("desktop_releases", Document::new(), None, 0, None).await?;
+        let mut releases: Vec<crate::routes::updates::ReleaseInfo> =
+            docs.iter().filter_map(parse_release_bson).collect();
+        // Newest first.
         releases.sort_by(|a, b| b.build_number.cmp(&a.build_number));
-
         Ok(releases)
     }
 
-    /// Parse Firestore document to ReleaseInfo
-    fn parse_release(
-        &self,
-        doc: &Value,
-    ) -> Result<crate::routes::updates::ReleaseInfo, Box<dyn std::error::Error + Send + Sync>> {
-        let fields = doc.get("fields").ok_or("Missing fields")?;
-
-        let changelog = if let Some(arr) = fields.get("changelog").and_then(|c| c.get("arrayValue")).and_then(|a| a.get("values")).and_then(|v| v.as_array()) {
-            arr.iter()
-                .filter_map(|v| v.get("stringValue").and_then(|s| s.as_str()))
-                .map(|s| s.to_string())
-                .collect()
-        } else {
-            vec![]
-        };
-
-        // channel: None = unpromoted (staging), Some("stable") = promoted stable
-        let channel = self.parse_string(fields, "channel");
-
-        Ok(crate::routes::updates::ReleaseInfo {
-            version: self.parse_string(fields, "version").unwrap_or_default(),
-            build_number: self.parse_int(fields, "build_number").unwrap_or(0) as u32,
-            download_url: self.parse_string(fields, "download_url").unwrap_or_default(),
-            ed_signature: self.parse_string(fields, "ed_signature").unwrap_or_default(),
-            published_at: self.parse_string(fields, "published_at").unwrap_or_default(),
-            changelog,
-            is_live: self.parse_bool(fields, "is_live").unwrap_or(false),
-            is_critical: self.parse_bool(fields, "is_critical").unwrap_or(false),
-            channel,
-        })
-    }
-
-    /// Create a new desktop release in Firestore
+    /// Create a new desktop release.
     pub async fn create_desktop_release(
         &self,
         release: &crate::routes::updates::ReleaseInfo,
     ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
         let doc_id = format!("v{}+{}", release.version, release.build_number);
-
-        let url = format!(
-            "{}/desktop_releases/{}",
-            self.base_url(),
-            doc_id
-        );
-
-        // Build changelog array
-        let changelog_values: Vec<Value> = release.changelog
-            .iter()
-            .map(|s| json!({"stringValue": s}))
-            .collect();
-
-        // Channel field: always a string. None/empty → "staging" (unpromoted default)
-        let channel_value = match &release.channel {
-            Some(ch) if !ch.is_empty() => json!({"stringValue": ch}),
-            _ => json!({"stringValue": "staging"}),
+        let path = format!("desktop_releases/{}", doc_id);
+        // None/empty channel → "staging" (unpromoted default).
+        let channel = match &release.channel {
+            Some(ch) if !ch.is_empty() => ch.clone(),
+            _ => "staging".to_string(),
         };
-
-        let doc = json!({
-            "fields": {
-                "version": {"stringValue": release.version},
-                "build_number": {"integerValue": release.build_number.to_string()},
-                "download_url": {"stringValue": release.download_url},
-                "ed_signature": {"stringValue": release.ed_signature},
-                "published_at": {"stringValue": release.published_at},
-                "changelog": {"arrayValue": {"values": changelog_values}},
-                "is_live": {"booleanValue": release.is_live},
-                "is_critical": {"booleanValue": release.is_critical},
-                "channel": channel_value
-            }
-        });
-
-        let response = self
-            .build_request(reqwest::Method::PATCH, &url)
-            .await?
-            .json(&doc)
-            .send()
-            .await?;
-
-        if !response.status().is_success() {
-            let error_text = response.text().await?;
-            return Err(format!("Firestore create error: {}", error_text).into());
-        }
-
+        let changelog: Vec<Bson> = release.changelog.iter().map(|s| Bson::String(s.clone())).collect();
+        let fields = doc! {
+            "version": &release.version,
+            "build_number": release.build_number as i64,
+            "download_url": &release.download_url,
+            "ed_signature": &release.ed_signature,
+            "published_at": &release.published_at,
+            "changelog": Bson::Array(changelog),
+            "is_live": release.is_live,
+            "is_critical": release.is_critical,
+            "channel": channel,
+        };
+        self.mongo.set(&path, fields).await?;
         tracing::info!("Created desktop release: {}", doc_id);
         Ok(doc_id)
     }
 
-    /// Promote a desktop release to the next channel: staging → beta → stable
-    /// Returns (old_channel, new_channel)
+    /// Promote a desktop release to the next channel: staging → beta → stable.
+    /// Returns (old_channel, new_channel).
     pub async fn promote_desktop_release(
         &self,
         doc_id: &str,
     ) -> Result<(String, String), Box<dyn std::error::Error + Send + Sync>> {
-        // Fetch the current document
-        let url = format!(
-            "{}/desktop_releases/{}",
-            self.base_url(),
-            doc_id
-        );
-
-        let response = self
-            .build_request(reqwest::Method::GET, &url)
+        let path = format!("desktop_releases/{}", doc_id);
+        let doc = self
+            .mongo
+            .get(&path)
             .await?
-            .send()
-            .await?;
-
-        if !response.status().is_success() {
-            let error_text = response.text().await?;
-            return Err(format!("Release not found: {}", error_text).into());
-        }
-
-        let doc: Value = response.json().await?;
-        let fields = doc.get("fields").ok_or("Missing fields in document")?;
-        let current_channel = self.parse_string(fields, "channel").unwrap_or_default();
-
-        // Determine next channel
-        let (old_channel, new_channel_value) = match current_channel.as_str() {
-            "staging" | "" => ("staging".to_string(), json!({"stringValue": "beta"})),
-            "beta" => ("beta".to_string(), json!({"stringValue": "stable"})),
+            .ok_or_else(|| format!("Release not found: {}", doc_id))?;
+        let current_channel = doc.get_str("channel").unwrap_or("").to_string();
+        let (old_channel, new_channel) = match current_channel.as_str() {
+            "staging" | "" => ("staging".to_string(), "beta".to_string()),
+            "beta" => ("beta".to_string(), "stable".to_string()),
             "stable" => return Err("Release is already on stable channel, cannot promote further".into()),
             other => return Err(format!("Unknown channel '{}', cannot promote", other).into()),
         };
-
-        let new_channel = new_channel_value.get("stringValue").and_then(|v| v.as_str()).unwrap().to_string();
-
-        // PATCH only the channel field
-        let patch_url = format!(
-            "{}/desktop_releases/{}?updateMask.fieldPaths=channel",
-            self.base_url(),
-            doc_id
-        );
-
-        let patch_doc = json!({
-            "fields": {
-                "channel": new_channel_value
-            }
-        });
-
-        let response = self
-            .build_request(reqwest::Method::PATCH, &patch_url)
-            .await?
-            .json(&patch_doc)
-            .send()
-            .await?;
-
-        if !response.status().is_success() {
-            let error_text = response.text().await?;
-            return Err(format!("Failed to update channel: {}", error_text).into());
-        }
-
+        self.mongo.apply(&path, doc! {"$set": {"channel": &new_channel}}, false).await?;
         tracing::info!("Promoted release {}: {} → {}", doc_id, old_channel, new_channel);
-
         Ok((old_channel, new_channel))
     }
 
@@ -9458,94 +9328,37 @@ impl FirestoreService {
         &self,
         uid: &str,
     ) -> Result<Option<crate::models::agent::AgentVm>, Box<dyn std::error::Error + Send + Sync>> {
-        let doc = self.get_user_document(uid).await?;
-        let empty = json!({});
-        let fields = doc.get("fields").unwrap_or(&empty);
-
-        let agent_vm = fields.get("agentVm");
-        if agent_vm.is_none() {
-            return Ok(None);
-        }
-
-        let map_value = agent_vm
-            .and_then(|v| v.get("mapValue"))
-            .and_then(|v| v.get("fields"));
-
-        if map_value.is_none() {
-            return Ok(None);
-        }
-
-        let f = map_value.unwrap();
-
-        let vm_name = f
-            .get("vmName")
-            .and_then(|v| v.get("stringValue"))
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string();
-
+        // MongoDB user doc; `agentVm` is a plain nested document.
+        let doc = match self.mongo.get(&format!("{}/{}", USERS_COLLECTION, uid)).await? {
+            Some(d) => d,
+            None => return Ok(None),
+        };
+        let vm = match doc.get_document("agentVm").ok() {
+            Some(v) => v,
+            None => return Ok(None),
+        };
+        let vm_name = vm.get_str("vmName").unwrap_or("").to_string();
         if vm_name.is_empty() {
             return Ok(None);
         }
-
-        let zone = f
-            .get("zone")
-            .and_then(|v| v.get("stringValue"))
-            .and_then(|v| v.as_str())
-            .unwrap_or("us-central1-a")
-            .to_string();
-
-        let ip = f
-            .get("ip")
-            .and_then(|v| v.get("stringValue"))
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string());
-
-        let status_str = f
-            .get("status")
-            .and_then(|v| v.get("stringValue"))
-            .and_then(|v| v.as_str())
-            .unwrap_or("provisioning");
-
-        let status = match status_str {
+        let status = match vm.get_str("status").unwrap_or("provisioning") {
             "ready" => crate::models::agent::AgentVmStatus::Ready,
             "stopped" => crate::models::agent::AgentVmStatus::Stopped,
             "error" => crate::models::agent::AgentVmStatus::Error,
             _ => crate::models::agent::AgentVmStatus::Provisioning,
         };
-
-        let auth_token = f
-            .get("authToken")
-            .and_then(|v| v.get("stringValue"))
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string();
-
-        let created_at = f
-            .get("createdAt")
-            .and_then(|v| v.get("stringValue"))
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string();
-
-        let last_query_at = f
-            .get("lastQueryAt")
-            .and_then(|v| v.get("stringValue"))
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string());
-
         Ok(Some(crate::models::agent::AgentVm {
             vm_name,
-            zone,
-            ip,
+            zone: vm.get_str("zone").unwrap_or("us-central1-a").to_string(),
+            ip: vm.get_str("ip").ok().map(String::from),
             status,
-            auth_token,
-            created_at,
-            last_query_at,
+            auth_token: vm.get_str("authToken").unwrap_or("").to_string(),
+            created_at: vm.get_str("createdAt").unwrap_or("").to_string(),
+            last_query_at: vm.get_str("lastQueryAt").ok().map(String::from),
         }))
     }
 
-    /// Set agent VM info on a user's document
+    /// Set agent VM info on a user's document (`agentVm` nested field).
     pub async fn set_agent_vm(
         &self,
         uid: &str,
@@ -9556,49 +9369,37 @@ impl FirestoreService {
         auth_token: &str,
         created_at: &str,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        let mut vm_fields = json!({
-            "vmName": {"stringValue": vm_name},
-            "zone": {"stringValue": zone},
-            "status": {"stringValue": status.to_string()},
-            "authToken": {"stringValue": auth_token},
-            "createdAt": {"stringValue": created_at}
-        });
-
+        let mut vm = doc! {
+            "vmName": vm_name,
+            "zone": zone,
+            "status": status.to_string(),
+            "authToken": auth_token,
+            "createdAt": created_at,
+        };
         if let Some(ip_val) = ip {
-            vm_fields.as_object_mut().unwrap().insert(
-                "ip".to_string(),
-                json!({"stringValue": ip_val}),
-            );
+            vm.insert("ip", ip_val);
         }
-
-        let fields = json!({
-            "agentVm": {
-                "mapValue": {
-                    "fields": vm_fields
-                }
-            }
-        });
-
-        self.update_user_fields(uid, fields, &["agentVm"]).await
+        self.mongo
+            .apply(&format!("{}/{}", USERS_COLLECTION, uid), doc! {"$set": {"agentVm": vm}}, true)
+            .await?;
+        Ok(())
     }
 
-    /// Delete the agentVm field from a user's document.
-    /// Used when the GCE VM no longer exists in GCP.
-    pub async fn delete_agent_vm(
-        &self,
-        uid: &str,
-    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        // Omitting agentVm from the body while including it in the update mask
-        // causes Firestore to delete the field.
-        self.update_user_fields(uid, json!({}), &["agentVm"]).await
+    /// Delete the `agentVm` field from a user's document (GCE VM gone).
+    pub async fn delete_agent_vm(&self, uid: &str) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        self.mongo
+            .apply(&format!("{}/{}", USERS_COLLECTION, uid), doc! {"$unset": {"agentVm": ""}}, false)
+            .await?;
+        Ok(())
     }
 
     // =========================================================================
     // SCREEN ACTIVITY
     // =========================================================================
 
-    /// Batch write screen activity rows to Firestore users/{uid}/screen_activity/{id}.
-    /// Uses Firestore commit API for batch writes (max 500 per commit).
+    /// Upsert screen activity rows to MongoDB users/{uid}/screen_activity/{id}.
+    /// (Python's screen_activity.py is still Firestore — a known straggler; both
+    /// use the shared shim collection `screen_activity`, so they align once it's migrated.)
     pub async fn upsert_screen_activity(
         &self,
         uid: &str,
@@ -9607,66 +9408,24 @@ impl FirestoreService {
         if rows.is_empty() {
             return Ok(0);
         }
-
         let mut written = 0;
-
-        for chunk in rows.chunks(500) {
-            let writes: Vec<Value> = chunk
-                .iter()
-                .map(|row| {
-                    let doc_name = format!(
-                        "projects/{}/databases/(default)/documents/{}/{}/{}/{}",
-                        self.project_id,
-                        USERS_COLLECTION,
-                        uid,
-                        SCREEN_ACTIVITY_SUBCOLLECTION,
-                        row.id
-                    );
-
-                    // Truncate OCR text to 1000 chars
-                    let ocr_truncated: String = row.ocr_text.chars().take(1000).collect();
-
-                    json!({
-                        "update": {
-                            "name": doc_name,
-                            "fields": {
-                                "timestamp": {"stringValue": &row.timestamp},
-                                "appName": {"stringValue": &row.app_name},
-                                "windowTitle": {"stringValue": &row.window_title},
-                                "ocrText": {"stringValue": ocr_truncated},
-                            }
-                        }
-                    })
-                })
-                .collect();
-
-            let commit_url = format!(
-                "https://firestore.googleapis.com/v1/projects/{}/databases/(default)/documents:commit",
-                self.project_id
+        for row in rows {
+            let path = format!(
+                "{}/{}/{}/{}",
+                USERS_COLLECTION, uid, SCREEN_ACTIVITY_SUBCOLLECTION, row.id
             );
-
-            let body = json!({ "writes": writes });
-
-            let response = self
-                .build_request(reqwest::Method::POST, &commit_url)
-                .await?
-                .json(&body)
-                .send()
-                .await?;
-
-            if !response.status().is_success() {
-                let error_text = response.text().await?;
-                return Err(format!("Firestore screen_activity batch commit error: {}", error_text).into());
-            }
-
-            written += chunk.len();
+            // Truncate OCR text to 1000 chars (parity with the Firestore version).
+            let ocr_truncated: String = row.ocr_text.chars().take(1000).collect();
+            let fields = doc! {
+                "timestamp": &row.timestamp,
+                "appName": &row.app_name,
+                "windowTitle": &row.window_title,
+                "ocrText": ocr_truncated,
+            };
+            self.mongo.set(&path, fields).await?;
+            written += 1;
         }
-
-        tracing::info!(
-            "Screen activity Firestore write uid={} count={}",
-            uid,
-            written
-        );
+        tracing::info!("Screen activity Mongo write uid={} count={}", uid, written);
         Ok(written)
     }
 }
@@ -9840,6 +9599,25 @@ fn parse_effective_plan_bson(doc: Option<&Document>) -> String {
         Some(pe) if pe >= chrono::Utc::now().timestamp() => plan,
         _ => "basic".to_string(),
     }
+}
+
+/// Parse a desktop_releases document (shared shim format) into `ReleaseInfo`.
+fn parse_release_bson(d: &Document) -> Option<crate::routes::updates::ReleaseInfo> {
+    let changelog = d
+        .get_array("changelog")
+        .map(|arr| arr.iter().filter_map(|v| v.as_str().map(String::from)).collect())
+        .unwrap_or_default();
+    Some(crate::routes::updates::ReleaseInfo {
+        version: d.get_str("version").unwrap_or("").to_string(),
+        build_number: bson_i32(d, "build_number").unwrap_or(0) as u32,
+        download_url: d.get_str("download_url").unwrap_or("").to_string(),
+        ed_signature: d.get_str("ed_signature").unwrap_or("").to_string(),
+        published_at: d.get_str("published_at").unwrap_or("").to_string(),
+        changelog,
+        is_live: d.get_bool("is_live").unwrap_or(false),
+        is_critical: d.get_bool("is_critical").unwrap_or(false),
+        channel: d.get_str("channel").ok().map(String::from),
+    })
 }
 
 #[cfg(test)]
@@ -10229,5 +10007,83 @@ mod tests {
             }
         });
         assert_eq!(parse_effective_plan_from_doc(&doc), "enterprise");
+    }
+
+    /// End-to-end desktop_releases + agent_vm + screen_activity round-trip against
+    /// a real MongoDB. Ignored by default — run with
+    /// `MONGO_TEST_URL=mongodb://localhost:27018 cargo test -- --ignored releases_and_agent_vm_mongo_roundtrip`.
+    #[tokio::test]
+    #[ignore]
+    async fn releases_and_agent_vm_mongo_roundtrip() {
+        let url = std::env::var("MONGO_TEST_URL").expect("set MONGO_TEST_URL");
+        std::env::set_var("MONGODB_URL", &url);
+        std::env::set_var("MONGODB_DB", "omi_rel_test");
+        let fs = FirestoreService::new("test-project".to_string(), None).await.unwrap();
+
+        // desktop_releases: create -> get -> promote
+        let rel = crate::routes::updates::ReleaseInfo {
+            version: "1.2.3".to_string(),
+            build_number: 99,
+            download_url: "https://x/y.zip".to_string(),
+            ed_signature: "sig".to_string(),
+            published_at: "2026-06-08T00:00:00Z".to_string(),
+            changelog: vec!["a".to_string(), "b".to_string()],
+            is_live: true,
+            is_critical: false,
+            channel: None,
+        };
+        let id = fs.create_desktop_release(&rel).await.unwrap();
+        assert_eq!(id, "v1.2.3+99");
+        let list = fs.get_desktop_releases().await.unwrap();
+        let got = list.iter().find(|r| r.build_number == 99).expect("release present");
+        assert_eq!(got.version, "1.2.3");
+        assert_eq!(got.changelog, vec!["a".to_string(), "b".to_string()]);
+        assert_eq!(got.channel.as_deref(), Some("staging")); // defaulted on create
+        let (old, new) = fs.promote_desktop_release(&id).await.unwrap();
+        assert_eq!((old.as_str(), new.as_str()), ("staging", "beta"));
+        fs.mongo.delete(&format!("desktop_releases/{}", id)).await.unwrap();
+
+        // agent_vm: set -> get -> delete
+        let uid = "u_vm_test";
+        let upath = format!("users/{}", uid);
+        fs.mongo.delete(&upath).await.unwrap();
+        assert!(fs.get_agent_vm(uid).await.unwrap().is_none());
+        fs.set_agent_vm(
+            uid,
+            "vm-1",
+            "us-central1-a",
+            Some("10.0.0.1"),
+            crate::models::agent::AgentVmStatus::Ready,
+            "tok",
+            "2026-06-08T00:00:00Z",
+        )
+        .await
+        .unwrap();
+        let vm = fs.get_agent_vm(uid).await.unwrap().expect("vm present");
+        assert_eq!(vm.vm_name, "vm-1");
+        assert_eq!(vm.ip.as_deref(), Some("10.0.0.1"));
+        assert_eq!(vm.status, crate::models::agent::AgentVmStatus::Ready);
+        fs.delete_agent_vm(uid).await.unwrap();
+        assert!(fs.get_agent_vm(uid).await.unwrap().is_none());
+
+        // screen_activity: upsert
+        let rows = vec![crate::models::screen_activity::ScreenActivityRow {
+            id: 1717000000,
+            timestamp: "2026-06-08 10:00:00.000".to_string(),
+            app_name: "Safari".to_string(),
+            window_title: "Inbox".to_string(),
+            ocr_text: "hello".to_string(),
+            embedding: None,
+        }];
+        assert_eq!(fs.upsert_screen_activity(uid, &rows).await.unwrap(), 1);
+        let sa = fs
+            .mongo
+            .get(&format!("users/{}/screen_activity/{}", uid, 1717000000i64))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(sa.get_str("appName").unwrap(), "Safari");
+        fs.mongo.delete(&format!("users/{}/screen_activity/{}", uid, 1717000000i64)).await.unwrap();
+        fs.mongo.delete(&upath).await.unwrap();
     }
 }

--- a/desktop/Backend-Rust/src/services/firestore_shim.rs
+++ b/desktop/Backend-Rust/src/services/firestore_shim.rs
@@ -1,0 +1,220 @@
+//! Firestore-REST-over-MongoDB shim.
+//!
+//! Strategy (mirrors the Python backend's `mongo_firestore.py`): keep the
+//! upstream Firestore methods in `firestore.rs` UNCHANGED and redirect their REST
+//! calls to MongoDB at a single seam, so upstream merges stay clean and nothing
+//! actually talks to Google Firestore.
+//!
+//! This module holds the **typed-value converter** — the translation between
+//! Firestore's REST JSON value encoding and BSON. The request dispatcher and the
+//! `firestore.rs` seam wiring build on top of it.
+//!
+//! Firestore REST encodes every field as a single-key "Value" object:
+//!   {"stringValue": "x"} {"integerValue": "5"} {"doubleValue": 1.5}
+//!   {"booleanValue": true} {"timestampValue": "2026-..Z"} {"nullValue": null}
+//!   {"mapValue": {"fields": {k: Value}}} {"arrayValue": {"values": [Value]}}
+//! (integerValue is a *string* in REST JSON.) A document body is {"fields": {k: Value}}.
+#![allow(dead_code)]
+
+use bson::{Bson, Document};
+use chrono::{DateTime, Utc};
+use serde_json::{json, Map, Value};
+
+/// Convert one Firestore REST "Value" object into BSON.
+pub fn value_to_bson(v: &Value) -> Bson {
+    let obj = match v.as_object() {
+        Some(o) => o,
+        None => return Bson::Null,
+    };
+    if let Some(s) = obj.get("stringValue").and_then(|x| x.as_str()) {
+        return Bson::String(s.to_string());
+    }
+    if let Some(i) = obj.get("integerValue") {
+        // REST encodes integers as strings, but tolerate a raw number too.
+        let parsed = i
+            .as_str()
+            .and_then(|s| s.parse::<i64>().ok())
+            .or_else(|| i.as_i64());
+        return Bson::Int64(parsed.unwrap_or(0));
+    }
+    if let Some(d) = obj.get("doubleValue") {
+        return Bson::Double(d.as_f64().unwrap_or(0.0));
+    }
+    if let Some(b) = obj.get("booleanValue") {
+        return Bson::Boolean(b.as_bool().unwrap_or(false));
+    }
+    if let Some(t) = obj.get("timestampValue").and_then(|x| x.as_str()) {
+        return match DateTime::parse_from_rfc3339(t) {
+            Ok(dt) => Bson::DateTime(bson::DateTime::from_chrono(dt.with_timezone(&Utc))),
+            Err(_) => Bson::String(t.to_string()),
+        };
+    }
+    if obj.contains_key("nullValue") {
+        return Bson::Null;
+    }
+    if let Some(m) = obj.get("mapValue") {
+        let fields = m.get("fields").and_then(|f| f.as_object());
+        return Bson::Document(fields_to_document(fields.unwrap_or(&Map::new())));
+    }
+    if let Some(a) = obj.get("arrayValue") {
+        let values = a.get("values").and_then(|v| v.as_array());
+        let arr = values
+            .map(|vs| vs.iter().map(value_to_bson).collect())
+            .unwrap_or_default();
+        return Bson::Array(arr);
+    }
+    Bson::Null
+}
+
+/// Convert a Firestore REST `fields` map into a BSON document.
+pub fn fields_to_document(fields: &Map<String, Value>) -> Document {
+    let mut doc = Document::new();
+    for (k, v) in fields {
+        doc.insert(k.clone(), value_to_bson(v));
+    }
+    doc
+}
+
+/// Convert a BSON value into a Firestore REST "Value" object.
+pub fn bson_to_value(b: &Bson) -> Value {
+    match b {
+        Bson::String(s) => json!({ "stringValue": s }),
+        Bson::Int32(i) => json!({ "integerValue": i.to_string() }),
+        Bson::Int64(i) => json!({ "integerValue": i.to_string() }),
+        Bson::Double(d) => json!({ "doubleValue": d }),
+        Bson::Boolean(b) => json!({ "booleanValue": b }),
+        Bson::DateTime(dt) => json!({ "timestampValue": dt.to_chrono().to_rfc3339() }),
+        Bson::Null => json!({ "nullValue": null }),
+        Bson::Document(d) => json!({ "mapValue": { "fields": document_to_fields(d) } }),
+        Bson::Array(arr) => {
+            json!({ "arrayValue": { "values": arr.iter().map(bson_to_value).collect::<Vec<_>>() } })
+        }
+        // Anything else (rarely used by this backend) degrades to its string form.
+        other => json!({ "stringValue": other.to_string() }),
+    }
+}
+
+/// Convert a BSON document into a Firestore REST `fields` object, skipping the
+/// shim's reserved keys (`_id`/`_p`/`_k`).
+pub fn document_to_fields(doc: &Document) -> Value {
+    let mut fields = Map::new();
+    for (k, v) in doc {
+        if k == "_id" || k == "_p" || k == "_k" {
+            continue;
+        }
+        fields.insert(k.clone(), bson_to_value(v));
+    }
+    Value::Object(fields)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scalar_roundtrips() {
+        assert_eq!(
+            value_to_bson(&json!({"stringValue": "hi"})),
+            Bson::String("hi".into())
+        );
+        assert_eq!(
+            value_to_bson(&json!({"integerValue": "42"})),
+            Bson::Int64(42)
+        );
+        assert_eq!(value_to_bson(&json!({"integerValue": 7})), Bson::Int64(7)); // tolerate raw number
+        assert_eq!(
+            value_to_bson(&json!({"doubleValue": 1.5})),
+            Bson::Double(1.5)
+        );
+        assert_eq!(
+            value_to_bson(&json!({"booleanValue": true})),
+            Bson::Boolean(true)
+        );
+        assert_eq!(value_to_bson(&json!({"nullValue": null})), Bson::Null);
+    }
+
+    #[test]
+    fn timestamp_to_bson_datetime() {
+        let b = value_to_bson(&json!({"timestampValue": "2026-06-08T10:00:00Z"}));
+        match b {
+            Bson::DateTime(_) => {}
+            other => panic!("expected datetime, got {:?}", other),
+        }
+        // round-trips back to an RFC3339 timestampValue
+        let v = bson_to_value(&b);
+        assert!(v
+            .get("timestampValue")
+            .and_then(|t| t.as_str())
+            .unwrap()
+            .starts_with("2026-06-08T10:00:00"));
+    }
+
+    #[test]
+    fn nested_map_and_array() {
+        let fs = json!({
+            "mapValue": { "fields": {
+                "active": {"booleanValue": true},
+                "fingerprints": {"mapValue": {"fields": {"openai": {"stringValue": "abc"}}}},
+                "tags": {"arrayValue": {"values": [{"stringValue": "a"}, {"stringValue": "b"}]}},
+            }}
+        });
+        let b = value_to_bson(&fs);
+        let d = b.as_document().unwrap();
+        assert_eq!(d.get_bool("active").unwrap(), true);
+        assert_eq!(
+            d.get_document("fingerprints")
+                .unwrap()
+                .get_str("openai")
+                .unwrap(),
+            "abc"
+        );
+        assert_eq!(d.get_array("tags").unwrap().len(), 2);
+    }
+
+    #[test]
+    fn document_to_fields_skips_reserved() {
+        let mut d = Document::new();
+        d.insert("_id", "users/u/action_items/1");
+        d.insert("_p", "users/u/action_items");
+        d.insert("_k", "1");
+        d.insert("description", "buy milk");
+        d.insert("completed", false);
+        let fields = document_to_fields(&d);
+        let obj = fields.as_object().unwrap();
+        assert!(!obj.contains_key("_id") && !obj.contains_key("_p") && !obj.contains_key("_k"));
+        assert_eq!(obj["description"], json!({"stringValue": "buy milk"}));
+        assert_eq!(obj["completed"], json!({"booleanValue": false}));
+    }
+
+    #[test]
+    fn fields_to_document_builds_bson() {
+        let fields = json!({
+            "description": {"stringValue": "x"},
+            "relevance_score": {"integerValue": "5"},
+            "completed": {"booleanValue": true},
+        });
+        let d = fields_to_document(fields.as_object().unwrap());
+        assert_eq!(d.get_str("description").unwrap(), "x");
+        assert_eq!(d.get_i64("relevance_score").unwrap(), 5);
+        assert_eq!(d.get_bool("completed").unwrap(), true);
+    }
+
+    #[test]
+    fn full_value_roundtrip_preserves_shape() {
+        let original = json!({
+            "mapValue": {"fields": {
+                "n": {"integerValue": "10"},
+                "f": {"doubleValue": 2.5},
+                "s": {"stringValue": "hi"},
+                "b": {"booleanValue": false},
+            }}
+        });
+        let back = bson_to_value(&value_to_bson(&original));
+        // integerValue stays string-encoded per the REST contract
+        let bf = back["mapValue"]["fields"].as_object().unwrap();
+        assert_eq!(bf["n"], json!({"integerValue": "10"}));
+        assert_eq!(bf["f"], json!({"doubleValue": 2.5}));
+        assert_eq!(bf["s"], json!({"stringValue": "hi"}));
+        assert_eq!(bf["b"], json!({"booleanValue": false}));
+    }
+}

--- a/desktop/Backend-Rust/src/services/firestore_shim.rs
+++ b/desktop/Backend-Rust/src/services/firestore_shim.rs
@@ -107,6 +107,267 @@ pub fn document_to_fields(doc: &Document) -> Value {
     Value::Object(fields)
 }
 
+// ===========================================================================
+// Request dispatcher: Firestore REST operation -> MongoStore
+// ===========================================================================
+
+use bson::doc;
+use super::mongo_store::MongoStore;
+
+const DOCS_MARKER: &str = "/databases/(default)/documents";
+
+/// True for the Firestore REST URLs the shim intercepts (vs. GCE compute /
+/// identitytoolkit URLs, which pass through to real GCP).
+pub fn is_firestore_url(url: &str) -> bool {
+    url.contains("firestore.googleapis.com") && url.contains(DOCS_MARKER)
+}
+
+/// Extract the resource path (everything after `/databases/(default)/documents`,
+/// keeping any `:runQuery`/`:commit` suffix, no leading slash) and the
+/// `updateMask.fieldPaths` values from a Firestore REST URL.
+pub fn parse_firestore_url(url: &str) -> Option<(String, Vec<String>)> {
+    let after = url.split(DOCS_MARKER).nth(1)?;
+    let (path_part, query) = match after.split_once('?') {
+        Some((p, q)) => (p, Some(q)),
+        None => (after, None),
+    };
+    let resource = path_part.trim_start_matches('/').to_string();
+    let mut mask = Vec::new();
+    if let Some(q) = query {
+        for kv in q.split('&') {
+            if let Some(v) = kv.strip_prefix("updateMask.fieldPaths=") {
+                mask.push(v.to_string());
+            }
+        }
+    }
+    Some((resource, mask))
+}
+
+/// `name = projects/{p}/databases/(default)/documents/{path}` -> `{path}`.
+fn doc_path_from_name(name: &str) -> String {
+    name.split(DOCS_MARKER).nth(1).unwrap_or(name).trim_start_matches('/').to_string()
+}
+
+/// Render a Mongo doc as a Firestore REST document JSON object.
+fn firestore_doc(path: &str, doc: &Document) -> Value {
+    json!({
+        "name": format!("projects/_/databases/(default)/documents/{}", path),
+        "fields": document_to_fields(doc),
+        "createTime": "1970-01-01T00:00:00Z",
+        "updateTime": "1970-01-01T00:00:00Z",
+    })
+}
+
+fn op_to_mongo(op: &str, value: Bson) -> Document {
+    match op {
+        "NOT_EQUAL" => doc! {"$ne": value},
+        "LESS_THAN" => doc! {"$lt": value},
+        "LESS_THAN_OR_EQUAL" => doc! {"$lte": value},
+        "GREATER_THAN" => doc! {"$gt": value},
+        "GREATER_THAN_OR_EQUAL" => doc! {"$gte": value},
+        "ARRAY_CONTAINS" => doc! {"$eq": value},
+        "IN" | "ARRAY_CONTAINS_ANY" => match value {
+            Bson::Array(a) => doc! {"$in": a},
+            other => doc! {"$in": [other]},
+        },
+        // EQUAL and anything unrecognized
+        _ => doc! {"$eq": value},
+    }
+}
+
+/// Translate a structuredQuery `where` (fieldFilter or compositeFilter) into a
+/// Mongo match document.
+fn where_to_filter(w: &Value) -> Document {
+    if let Some(ff) = w.get("fieldFilter") {
+        let field = ff.get("field").and_then(|f| f.get("fieldPath")).and_then(|v| v.as_str()).unwrap_or("");
+        let op = ff.get("op").and_then(|v| v.as_str()).unwrap_or("EQUAL");
+        let value = value_to_bson(ff.get("value").unwrap_or(&Value::Null));
+        let mut d = Document::new();
+        d.insert(field, op_to_mongo(op, value));
+        d
+    } else if let Some(comp) = w.get("compositeFilter") {
+        let op = comp.get("op").and_then(|v| v.as_str()).unwrap_or("AND");
+        let subs: Vec<Bson> = comp
+            .get("filters")
+            .and_then(|f| f.as_array())
+            .map(|arr| arr.iter().map(|f| Bson::Document(where_to_filter(f))).collect())
+            .unwrap_or_default();
+        let key = if op.eq_ignore_ascii_case("OR") { "$or" } else { "$and" };
+        let mut d = Document::new();
+        d.insert(key, subs);
+        d
+    } else {
+        Document::new()
+    }
+}
+
+/// Dispatch a Firestore REST request against MongoDB. Returns (http_status, body).
+pub async fn dispatch(mongo: &MongoStore, method: &str, url: &str, body: Option<&Value>) -> (u16, Value) {
+    let (resource, mask) = match parse_firestore_url(url) {
+        Some(x) => x,
+        None => return (400, json!({"error": "unrecognized firestore url"})),
+    };
+
+    if resource == ":commit" || resource.ends_with(":commit") {
+        return commit(mongo, body).await;
+    }
+    if let Some(parent) = resource.strip_suffix(":runQuery") {
+        return run_query(mongo, parent, body).await;
+    }
+
+    match method {
+        "GET" => {
+            // Firestore: even segment count = document, odd = collection.
+            if resource.split('/').count() % 2 == 0 {
+                match mongo.get(&resource).await {
+                    Ok(Some(d)) => (200, firestore_doc(&resource, &d)),
+                    Ok(None) => (404, json!({"error": {"status": "NOT_FOUND"}})),
+                    Err(e) => (500, json!({"error": e.to_string()})),
+                }
+            } else {
+                match mongo.query(&resource, Document::new(), None, 0, None).await {
+                    Ok(docs) => {
+                        let documents: Vec<Value> = docs
+                            .iter()
+                            .map(|d| firestore_doc(d.get_str("_id").unwrap_or(""), d))
+                            .collect();
+                        (200, json!({ "documents": documents }))
+                    }
+                    Err(e) => (500, json!({"error": e.to_string()})),
+                }
+            }
+        }
+        "PATCH" => {
+            let fields = body.and_then(|b| b.get("fields")).and_then(|f| f.as_object());
+            let mut set_doc = Document::new();
+            if let Some(f) = fields {
+                for (k, v) in f {
+                    set_doc.insert(k.clone(), value_to_bson(v));
+                }
+            }
+            let mut update = Document::new();
+            if !set_doc.is_empty() {
+                update.insert("$set", set_doc.clone());
+            }
+            // updateMask entries absent from the body => field deletions.
+            let mut unset = Document::new();
+            for m in &mask {
+                if fields.map(|f| !f.contains_key(m)).unwrap_or(true) {
+                    unset.insert(m.clone(), "");
+                }
+            }
+            if !unset.is_empty() {
+                update.insert("$unset", unset);
+            }
+            if update.is_empty() {
+                update.insert("$set", Document::new());
+            }
+            match mongo.apply(&resource, update, true).await {
+                Ok(_) => match mongo.get(&resource).await {
+                    Ok(Some(d)) => (200, firestore_doc(&resource, &d)),
+                    _ => (200, firestore_doc(&resource, &set_doc)),
+                },
+                Err(e) => (500, json!({"error": e.to_string()})),
+            }
+        }
+        "DELETE" => match mongo.delete(&resource).await {
+            Ok(_) => (200, json!({})),
+            Err(e) => (500, json!({"error": e.to_string()})),
+        },
+        _ => (405, json!({"error": "method not allowed"})),
+    }
+}
+
+async fn run_query(mongo: &MongoStore, parent: &str, body: Option<&Value>) -> (u16, Value) {
+    let sq = match body.and_then(|b| b.get("structuredQuery")) {
+        Some(q) => q,
+        None => return (400, json!({"error": "missing structuredQuery"})),
+    };
+    let collection_id = sq
+        .get("from")
+        .and_then(|f| f.as_array())
+        .and_then(|a| a.first())
+        .and_then(|f| f.get("collectionId"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let coll_path = if parent.is_empty() {
+        collection_id.to_string()
+    } else {
+        format!("{}/{}", parent, collection_id)
+    };
+
+    let mut extra = Document::new();
+    if let Some(w) = sq.get("where") {
+        for (k, v) in where_to_filter(w) {
+            extra.insert(k, v);
+        }
+    }
+    let sort = sq.get("orderBy").and_then(|o| o.as_array()).and_then(|arr| {
+        let mut s = Document::new();
+        for ob in arr {
+            let field = ob.get("field").and_then(|f| f.get("fieldPath")).and_then(|v| v.as_str()).unwrap_or("");
+            let dir = ob.get("direction").and_then(|v| v.as_str()).unwrap_or("ASCENDING");
+            s.insert(field, if dir == "DESCENDING" { -1 } else { 1 });
+        }
+        if s.is_empty() {
+            None
+        } else {
+            Some(s)
+        }
+    });
+    let limit = sq.get("limit").and_then(|v| v.as_i64());
+    let offset = sq.get("offset").and_then(|v| v.as_u64()).unwrap_or(0);
+
+    match mongo.query(&coll_path, extra, sort, offset, limit).await {
+        Ok(docs) => {
+            let rows: Vec<Value> = docs
+                .iter()
+                .map(|d| json!({ "document": firestore_doc(d.get_str("_id").unwrap_or(""), d) }))
+                .collect();
+            (200, Value::Array(rows))
+        }
+        Err(e) => (500, json!({"error": e.to_string()})),
+    }
+}
+
+async fn commit(mongo: &MongoStore, body: Option<&Value>) -> (u16, Value) {
+    let writes = match body.and_then(|b| b.get("writes")).and_then(|w| w.as_array()) {
+        Some(w) => w,
+        None => return (400, json!({"error": "missing writes"})),
+    };
+    let mut results = Vec::new();
+    for w in writes {
+        if let Some(update) = w.get("update") {
+            let path = doc_path_from_name(update.get("name").and_then(|v| v.as_str()).unwrap_or(""));
+            let mut set_doc = Document::new();
+            if let Some(f) = update.get("fields").and_then(|f| f.as_object()) {
+                for (k, v) in f {
+                    set_doc.insert(k.clone(), value_to_bson(v));
+                }
+            }
+            let _ = mongo.apply(&path, doc! {"$set": set_doc}, true).await;
+        } else if let Some(transform) = w.get("transform") {
+            let path = doc_path_from_name(transform.get("document").and_then(|v| v.as_str()).unwrap_or(""));
+            let mut inc = Document::new();
+            if let Some(fts) = transform.get("fieldTransforms").and_then(|v| v.as_array()) {
+                for ft in fts {
+                    let fp = ft.get("fieldPath").and_then(|v| v.as_str()).unwrap_or("");
+                    if let Some(incv) = ft.get("increment") {
+                        inc.insert(fp, value_to_bson(incv));
+                    }
+                }
+            }
+            if !inc.is_empty() {
+                let _ = mongo.apply(&path, doc! {"$inc": inc}, true).await;
+            }
+        } else if let Some(del) = w.get("delete").and_then(|v| v.as_str()) {
+            let _ = mongo.delete(&doc_path_from_name(del)).await;
+        }
+        results.push(json!({ "updateTime": "1970-01-01T00:00:00Z" }));
+    }
+    (200, json!({ "writeResults": results }))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -216,5 +477,109 @@ mod tests {
         assert_eq!(bf["f"], json!({"doubleValue": 2.5}));
         assert_eq!(bf["s"], json!({"stringValue": "hi"}));
         assert_eq!(bf["b"], json!({"booleanValue": false}));
+    }
+
+    // --- dispatcher tests ---
+
+    #[test]
+    fn url_parsing_and_firestore_detection() {
+        assert!(is_firestore_url("https://firestore.googleapis.com/v1/projects/p/databases/(default)/documents/users/u"));
+        assert!(!is_firestore_url("https://compute.googleapis.com/compute/v1/projects/p/zones"));
+        let (r, m) = parse_firestore_url("https://firestore.googleapis.com/v1/projects/p/databases/(default)/documents/users/u?updateMask.fieldPaths=agentVm").unwrap();
+        assert_eq!(r, "users/u");
+        assert_eq!(m, vec!["agentVm".to_string()]);
+        let (r2, _) = parse_firestore_url("https://firestore.googleapis.com/v1/projects/p/databases/(default)/documents:commit").unwrap();
+        assert_eq!(r2, ":commit");
+        let (r3, _) = parse_firestore_url("https://firestore.googleapis.com/v1/projects/p/databases/(default)/documents/users/u:runQuery").unwrap();
+        assert_eq!(r3, "users/u:runQuery");
+    }
+
+    #[test]
+    fn where_filter_translation() {
+        let ff = json!({"fieldFilter": {"field": {"fieldPath": "completed"}, "op": "EQUAL", "value": {"booleanValue": false}}});
+        let d = where_to_filter(&ff);
+        assert_eq!(d.get_document("completed").unwrap().get_bool("$eq").unwrap(), false);
+        let comp = json!({"compositeFilter": {"op": "AND", "filters": [
+            {"fieldFilter": {"field": {"fieldPath": "a"}, "op": "EQUAL", "value": {"stringValue": "x"}}},
+            {"fieldFilter": {"field": {"fieldPath": "n"}, "op": "GREATER_THAN_OR_EQUAL", "value": {"integerValue": "5"}}}
+        ]}});
+        let d2 = where_to_filter(&comp);
+        assert_eq!(d2.get_array("$and").unwrap().len(), 2);
+    }
+
+    fn furl(path: &str) -> String {
+        format!("https://firestore.googleapis.com/v1/projects/p/databases/(default)/documents/{}", path)
+    }
+
+    /// Drive the dispatcher with the exact REST shapes firestore.rs produces,
+    /// against a real MongoDB. Run with
+    /// `MONGO_TEST_URL=mongodb://localhost:27018 cargo test -- --ignored shim_dispatch_roundtrip`.
+    #[tokio::test]
+    #[ignore]
+    async fn shim_dispatch_roundtrip() {
+        let url = std::env::var("MONGO_TEST_URL").expect("set MONGO_TEST_URL");
+        let mongo = MongoStore::connect(&url, "omi_shim_test").await.unwrap();
+        let _ = mongo.delete("users/u/action_items/a1").await;
+
+        // PATCH create (action_items create_action_item shape) -> GET back
+        let body = json!({"fields": {
+            "description": {"stringValue": "buy milk"},
+            "completed": {"booleanValue": false},
+            "created_at": {"timestampValue": "2026-06-08T10:00:00Z"},
+        }});
+        let (st, _) = dispatch(&mongo, "PATCH", &furl("users/u/action_items/a1"), Some(&body)).await;
+        assert_eq!(st, 200);
+        let (st, doc) = dispatch(&mongo, "GET", &furl("users/u/action_items/a1"), None).await;
+        assert_eq!(st, 200);
+        assert_eq!(doc["fields"]["description"]["stringValue"], "buy milk");
+        assert_eq!(doc["fields"]["completed"]["booleanValue"], false);
+
+        // :runQuery (get_action_items shape): where completed==false, order created_at desc
+        let q = json!({"structuredQuery": {
+            "from": [{"collectionId": "action_items"}],
+            "where": {"fieldFilter": {"field": {"fieldPath": "completed"}, "op": "EQUAL", "value": {"booleanValue": false}}},
+            "orderBy": [{"field": {"fieldPath": "created_at"}, "direction": "DESCENDING"}],
+            "limit": 50
+        }});
+        let (st, rows) = dispatch(&mongo, "POST", &furl("users/u:runQuery"), Some(&q)).await;
+        assert_eq!(st, 200);
+        let arr = rows.as_array().unwrap();
+        assert!(arr.iter().any(|r| r["document"]["fields"]["description"]["stringValue"] == "buy milk"));
+
+        // :commit with field-transform increment (record_llm_usage shape)
+        let _ = mongo.delete("users/u/llm_usage/2026-06-08").await;
+        let commit = json!({"writes": [{"transform": {
+            "document": "projects/p/databases/(default)/documents/users/u/llm_usage/2026-06-08",
+            "fieldTransforms": [
+                {"fieldPath": "desktop_chat.call_count", "increment": {"integerValue": "1"}},
+                {"fieldPath": "desktop_chat.cost_usd", "increment": {"doubleValue": 0.5}}
+            ]
+        }}]});
+        let curl = "https://firestore.googleapis.com/v1/projects/p/databases/(default)/documents:commit";
+        dispatch(&mongo, "POST", curl, Some(&commit)).await;
+        dispatch(&mongo, "POST", curl, Some(&commit)).await;
+        let usage = mongo.get("users/u/llm_usage/2026-06-08").await.unwrap().unwrap();
+        let dc = usage.get_document("desktop_chat").unwrap();
+        assert_eq!(dc.get_i64("call_count").unwrap(), 2);
+        assert!((dc.get_f64("cost_usd").unwrap() - 1.0).abs() < 1e-9);
+
+        // PATCH with updateMask (merge agentVm) then field deletion (unset)
+        let setvm = json!({"fields": {"agentVm": {"mapValue": {"fields": {"vmName": {"stringValue": "vm-1"}}}}}});
+        dispatch(&mongo, "PATCH", &furl("users/u?updateMask.fieldPaths=agentVm"), Some(&setvm)).await;
+        let (_, ud) = dispatch(&mongo, "GET", &furl("users/u"), None).await;
+        assert_eq!(ud["fields"]["agentVm"]["mapValue"]["fields"]["vmName"]["stringValue"], "vm-1");
+        // unset: empty body + mask
+        dispatch(&mongo, "PATCH", &furl("users/u?updateMask.fieldPaths=agentVm"), Some(&json!({"fields": {}}))).await;
+        let raw = mongo.get("users/u").await.unwrap().unwrap();
+        assert!(!raw.contains_key("agentVm"));
+
+        // DELETE
+        dispatch(&mongo, "DELETE", &furl("users/u/action_items/a1"), None).await;
+        let (st, _) = dispatch(&mongo, "GET", &furl("users/u/action_items/a1"), None).await;
+        assert_eq!(st, 404);
+
+        // cleanup
+        let _ = mongo.delete("users/u").await;
+        let _ = mongo.delete("users/u/llm_usage/2026-06-08").await;
     }
 }

--- a/desktop/Backend-Rust/src/services/firestore_shim.rs
+++ b/desktop/Backend-Rust/src/services/firestore_shim.rs
@@ -368,6 +368,88 @@ async fn commit(mongo: &MongoStore, body: Option<&Value>) -> (u16, Value) {
     (200, json!({ "writeResults": results }))
 }
 
+// ===========================================================================
+// reqwest-shaped seam: build_request returns one of these. Firestore URLs route
+// to MongoDB (Mongo variant); everything else (GCE compute, identitytoolkit)
+// passes through to real reqwest (Real variant). Covers exactly the chained
+// methods firestore.rs and agent.rs use: .json()/.header()/.send() and the
+// response's .status()/.json()/.text().
+// ===========================================================================
+
+type BoxErr = Box<dyn std::error::Error + Send + Sync>;
+
+pub enum ShimRequest {
+    Real(reqwest::RequestBuilder),
+    Mongo {
+        method: String,
+        url: String,
+        body: Option<Value>,
+        mongo: MongoStore,
+    },
+}
+
+impl ShimRequest {
+    pub fn json<T: serde::Serialize + ?Sized>(self, body: &T) -> Self {
+        match self {
+            ShimRequest::Real(rb) => ShimRequest::Real(rb.json(body)),
+            ShimRequest::Mongo { method, url, mongo, .. } => ShimRequest::Mongo {
+                method,
+                url,
+                mongo,
+                body: serde_json::to_value(body).ok(),
+            },
+        }
+    }
+
+    pub fn header(self, key: &str, value: &str) -> Self {
+        match self {
+            ShimRequest::Real(rb) => ShimRequest::Real(rb.header(key, value)),
+            // Headers are irrelevant to the Mongo path (firestore URLs).
+            other => other,
+        }
+    }
+
+    pub async fn send(self) -> Result<ShimResponse, BoxErr> {
+        match self {
+            ShimRequest::Real(rb) => Ok(ShimResponse::Real(rb.send().await?)),
+            ShimRequest::Mongo { method, url, body, mongo } => {
+                let (status, value) = dispatch(&mongo, &method, &url, body.as_ref()).await;
+                Ok(ShimResponse::Mongo { status, value })
+            }
+        }
+    }
+}
+
+pub enum ShimResponse {
+    Real(reqwest::Response),
+    Mongo { status: u16, value: Value },
+}
+
+impl ShimResponse {
+    pub fn status(&self) -> reqwest::StatusCode {
+        match self {
+            ShimResponse::Real(r) => r.status(),
+            ShimResponse::Mongo { status, .. } => {
+                reqwest::StatusCode::from_u16(*status).unwrap_or(reqwest::StatusCode::INTERNAL_SERVER_ERROR)
+            }
+        }
+    }
+
+    pub async fn json<T: serde::de::DeserializeOwned>(self) -> Result<T, BoxErr> {
+        match self {
+            ShimResponse::Real(r) => Ok(r.json::<T>().await?),
+            ShimResponse::Mongo { value, .. } => Ok(serde_json::from_value(value)?),
+        }
+    }
+
+    pub async fn text(self) -> Result<String, BoxErr> {
+        match self {
+            ShimResponse::Real(r) => Ok(r.text().await?),
+            ShimResponse::Mongo { value, .. } => Ok(value.to_string()),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/desktop/Backend-Rust/src/services/mod.rs
+++ b/desktop/Backend-Rust/src/services/mod.rs
@@ -1,6 +1,7 @@
 // Services module
 
 pub mod firestore;
+pub mod firestore_shim;
 pub mod integrations;
 pub mod mongo_store;
 pub mod redis;

--- a/desktop/Backend-Rust/src/services/mod.rs
+++ b/desktop/Backend-Rust/src/services/mod.rs
@@ -2,8 +2,10 @@
 
 pub mod firestore;
 pub mod integrations;
+pub mod mongo_store;
 pub mod redis;
 
 pub use firestore::FirestoreService;
 pub use integrations::IntegrationService;
+pub use mongo_store::MongoStore;
 pub use redis::RedisService;

--- a/desktop/Backend-Rust/src/services/mongo_store.rs
+++ b/desktop/Backend-Rust/src/services/mongo_store.rs
@@ -1,0 +1,257 @@
+//! MongoDB data store — the Rust side of the dataset shared with the Python
+//! backend's `MongoFirestore` shim (`backend/database/mongo_firestore.py`).
+//!
+//! Storage model (path-faithful, no per-collection knowledge): a document at the
+//! Firestore-style path `users/abc/action_items/123` is stored in Mongo
+//! collection `action_items` as:
+//! ```text
+//! { "_id": "users/abc/action_items/123",   // full path
+//!   "_p":  "users/abc/action_items",        // parent collection path
+//!   "_k":  "123",                           // leaf doc id
+//!   ...user fields }
+//! ```
+//! A collection query filters on `_p`. This matches the Python shim exactly so
+//! both backends read and write one dataset.
+//!
+//! NOTE: wired into `FirestoreService` and the live data functions in Phase 2b;
+//! this module is the reusable storage core.
+#![allow(dead_code)]
+
+use bson::{doc, Bson, Document};
+use futures::stream::TryStreamExt;
+use mongodb::{Client, Collection, Database};
+
+/// Decompose a path into `(collection_name, parent_path, leaf_id)`, mirroring the
+/// Python shim's `DocumentReference`: collection = 2nd-to-last segment,
+/// parent = all but the last segment, id = last segment.
+pub fn path_parts(path: &str) -> (String, String, String) {
+    let segs: Vec<&str> = path.split('/').collect();
+    let leaf_id = segs.last().copied().unwrap_or("").to_string();
+    let parent = if segs.len() > 1 {
+        segs[..segs.len() - 1].join("/")
+    } else {
+        String::new()
+    };
+    let coll = if segs.len() >= 2 {
+        safe_collection(segs[segs.len() - 2])
+    } else {
+        safe_collection(&leaf_id)
+    };
+    (coll, parent, leaf_id)
+}
+
+/// Mongo collection names cannot contain `$` or spaces (matches Python `_safe`).
+pub fn safe_collection(name: &str) -> String {
+    name.replace('$', "_").replace(' ', "_")
+}
+
+/// Leaf collection name for a *collection* path,
+/// e.g. `users/abc/action_items` -> `action_items`.
+fn collection_of(parent_path: &str) -> String {
+    safe_collection(parent_path.rsplit('/').next().unwrap_or(parent_path))
+}
+
+/// Thin MongoDB handle exposing the path-faithful document operations the live
+/// data functions need. Cheap to clone (wraps an `Arc` client internally).
+#[derive(Clone)]
+pub struct MongoStore {
+    db: Database,
+}
+
+impl MongoStore {
+    /// Connect to MongoDB. `Client::with_uri_str` resolves lazily, so this
+    /// succeeds even if the server is momentarily unreachable — the first
+    /// operation surfaces a connection error instead.
+    pub async fn connect(url: &str, db_name: &str) -> mongodb::error::Result<Self> {
+        let client = Client::with_uri_str(url).await?;
+        Ok(Self {
+            db: client.database(db_name),
+        })
+    }
+
+    /// Escape hatch for callers that need raw collection access.
+    pub fn database(&self) -> &Database {
+        &self.db
+    }
+
+    fn coll(&self, name: &str) -> Collection<Document> {
+        self.db.collection::<Document>(name)
+    }
+
+    /// Firestore `.set()` without merge: replace the whole document with the base
+    /// path fields plus `fields`. Upserts.
+    pub async fn set(&self, path: &str, mut fields: Document) -> mongodb::error::Result<()> {
+        let (coll, parent, id) = path_parts(path);
+        fields.insert("_id", path);
+        fields.insert("_p", parent);
+        fields.insert("_k", id);
+        self.coll(&coll)
+            .replace_one(doc! {"_id": path}, fields)
+            .upsert(true)
+            .await?;
+        Ok(())
+    }
+
+    /// Firestore `.set(merge=True)` / `.update()`: apply a Mongo update document
+    /// (with `$set`/`$inc`/`$addToSet`/`$unset`), always stamping `_id`/`_p`/`_k`
+    /// into `$set`. `upsert` mirrors merge-set (true) vs update (false).
+    pub async fn apply(&self, path: &str, mut update: Document, upsert: bool) -> mongodb::error::Result<()> {
+        let (coll, parent, id) = path_parts(path);
+        let mut set_doc = match update.remove("$set") {
+            Some(Bson::Document(d)) => d,
+            _ => Document::new(),
+        };
+        set_doc.insert("_id", path);
+        set_doc.insert("_p", parent);
+        set_doc.insert("_k", id);
+        update.insert("$set", set_doc);
+        self.coll(&coll)
+            .update_one(doc! {"_id": path}, update)
+            .upsert(upsert)
+            .await?;
+        Ok(())
+    }
+
+    /// Fetch a single document by path (`None` if absent).
+    pub async fn get(&self, path: &str) -> mongodb::error::Result<Option<Document>> {
+        let (coll, _, _) = path_parts(path);
+        self.coll(&coll).find_one(doc! {"_id": path}).await
+    }
+
+    /// Delete a single document by path.
+    pub async fn delete(&self, path: &str) -> mongodb::error::Result<()> {
+        let (coll, _, _) = path_parts(path);
+        self.coll(&coll).delete_one(doc! {"_id": path}).await?;
+        Ok(())
+    }
+
+    /// Query the documents in a collection (scoped by parent path via `_p`), with
+    /// optional extra match clauses, sort, offset and limit.
+    pub async fn query(
+        &self,
+        parent_path: &str,
+        extra: Document,
+        sort: Option<Document>,
+        offset: u64,
+        limit: Option<i64>,
+    ) -> mongodb::error::Result<Vec<Document>> {
+        let coll = collection_of(parent_path);
+        let mut filter = doc! {"_p": parent_path};
+        for (k, v) in extra {
+            filter.insert(k, v);
+        }
+        let handle = self.coll(&coll);
+        let mut find = handle.find(filter);
+        if let Some(s) = sort {
+            find = find.sort(s);
+        }
+        if offset > 0 {
+            find = find.skip(offset);
+        }
+        if let Some(l) = limit {
+            find = find.limit(l);
+        }
+        let cursor = find.await?;
+        cursor.try_collect().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn path_parts_nested_subcollection() {
+        let (coll, parent, id) = path_parts("users/abc/action_items/123");
+        assert_eq!(coll, "action_items");
+        assert_eq!(parent, "users/abc/action_items");
+        assert_eq!(id, "123");
+    }
+
+    #[test]
+    fn path_parts_top_level_user_doc() {
+        // Matches Python: parts=["users","abc"] -> coll=parts[-2]="users",
+        // parent="users", id="abc".
+        let (coll, parent, id) = path_parts("users/abc");
+        assert_eq!(coll, "users");
+        assert_eq!(parent, "users");
+        assert_eq!(id, "abc");
+    }
+
+    #[test]
+    fn path_parts_date_keyed_doc() {
+        let (coll, parent, id) = path_parts("users/abc/llm_usage/2026-06-08");
+        assert_eq!(coll, "llm_usage");
+        assert_eq!(parent, "users/abc/llm_usage");
+        assert_eq!(id, "2026-06-08");
+    }
+
+    #[test]
+    fn safe_collection_strips_dollar_and_space() {
+        assert_eq!(safe_collection("a b$c"), "a_b_c");
+        assert_eq!(safe_collection("action_items"), "action_items");
+    }
+
+    #[test]
+    fn collection_of_returns_leaf() {
+        assert_eq!(collection_of("users/abc/action_items"), "action_items");
+        assert_eq!(collection_of("users"), "users");
+        assert_eq!(collection_of("desktop_releases"), "desktop_releases");
+    }
+
+    /// Round-trip against a real MongoDB. Ignored by default (CI has no Mongo);
+    /// run with `MONGO_TEST_URL=mongodb://localhost:27018 cargo test -- --ignored mongo_roundtrip`.
+    #[tokio::test]
+    #[ignore]
+    async fn mongo_roundtrip_matches_shim_format() {
+        let url = std::env::var("MONGO_TEST_URL").expect("set MONGO_TEST_URL");
+        let store = MongoStore::connect(&url, "omi_store_test").await.unwrap();
+        let path = "users/u1/action_items/a1";
+
+        // Clean slate.
+        store.delete(path).await.unwrap();
+
+        // set() writes base path fields + user fields.
+        store
+            .set(path, doc! {"description": "buy milk", "completed": false})
+            .await
+            .unwrap();
+
+        // Stored document carries the shim's reserved fields (_id/_p/_k).
+        let got = store.get(path).await.unwrap().expect("doc exists");
+        assert_eq!(got.get_str("_id").unwrap(), path);
+        assert_eq!(got.get_str("_p").unwrap(), "users/u1/action_items");
+        assert_eq!(got.get_str("_k").unwrap(), "a1");
+        assert_eq!(got.get_str("description").unwrap(), "buy milk");
+        assert_eq!(got.get_bool("completed").unwrap(), false);
+
+        // query() scopes by parent path and applies extra match clauses.
+        let rows = store
+            .query("users/u1/action_items", doc! {"completed": false}, None, 0, None)
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].get_str("_k").unwrap(), "a1");
+
+        // apply() merges with $set/$inc, preserving _p/_k.
+        store
+            .apply(path, doc! {"$set": {"completed": true}, "$inc": {"edits": 1}}, true)
+            .await
+            .unwrap();
+        let got = store.get(path).await.unwrap().unwrap();
+        assert_eq!(got.get_bool("completed").unwrap(), true);
+        assert_eq!(got.get_i32("edits").unwrap(), 1);
+        assert_eq!(got.get_str("_k").unwrap(), "a1"); // reserved fields intact
+
+        // A non-matching query returns nothing.
+        let none = store
+            .query("users/u1/action_items", doc! {"completed": false}, None, 0, None)
+            .await
+            .unwrap();
+        assert!(none.is_empty());
+
+        // delete() removes it.
+        store.delete(path).await.unwrap();
+        assert!(store.get(path).await.unwrap().is_none());
+    }
+}


### PR DESCRIPTION
## Summary

**Phase 2** of the desktop Rust backend self-hosting migration: the data layer no longer talks to Google Firestore — every Firestore REST call is served from the **same MongoDB the Python backend uses**, via a shim.

### Why a shim (not a rewrite)
`firestore.rs` is an **upstream-maintained file** (the fork tracks BasedHardware/omi, currently ~333 commits behind). Rewriting or deleting its functions would conflict on every upstream pull and Firestore code would keep returning. So, mirroring the Python backend's `mongo_firestore.py`, the upstream methods stay **byte-identical** and their REST calls are redirected to MongoDB at a single seam. Upstream merges stay clean.

### Pieces
- **`mongo_store.rs`** — path-faithful Mongo storage (`_id`/`_p`/`_k`, collection = leaf), shared format with the Python backend.
- **`firestore_shim.rs`**:
  - Firestore typed-value JSON ↔ BSON converter.
  - Request dispatcher: `GET`/`PATCH`/`DELETE`/`:runQuery`/`:commit` (incl. field-transform `$inc`) → `MongoStore`, returning Firestore-shaped JSON.
  - `ShimRequest`/`ShimResponse` — a reqwest-shaped seam (`.json`/`.header`/`.send` → `.status`/`.json`/`.text`).
- **`firestore.rs` seam (only ~30 non-test lines changed vs upstream)** — add a `mongo: MongoStore` field, connect it in `new()`, and make `build_request` route `firestore.googleapis.com` URLs to the shim (everything else — GCE Compute, Identity Toolkit — passes through to real reqwest with a bearer token). **Every method body is unchanged.**

### Result
- Nothing talks to Firestore at runtime; data lives in the shared Mongo.
- No upstream code deleted; `firestore.rs` diff vs upstream is a tiny seam → clean merges.
- GCP service-account token machinery stays only for the GCE agent-VM feature (Phase 4 → k8s).

## Tests
- Unit: typed-value converter, URL parsing, where→Mongo filter, Mongo path logic, BYOK/plan parsing.
- **`#[ignore]`d real-Mongo round-trips** (run with `MONGO_TEST_URL=mongodb://localhost:27018 cargo test -- --ignored`): MongoStore primitives; dispatcher driving the exact REST shapes; and an **end-to-end test driving the unchanged upstream methods** (action_items, byok/subscription, llm_usage+total, agent_vm, desktop_releases) through the shim.
- **260 unit tests pass**, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)